### PR TITLE
Feat/auth 회원 탈퇴 기능 구현 및 로그아웃

### DIFF
--- a/src/main/java/caffeine/nest_dev/common/config/JwtAuthenticationFilter.java
+++ b/src/main/java/caffeine/nest_dev/common/config/JwtAuthenticationFilter.java
@@ -39,39 +39,31 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (token != null) {
             // 토큰이 블랙리스트에 있는지 확인
+            log.info("블랙리스트에서 토큰 값 확인");
             String blacklistToken = stringRedisTemplate.opsForValue().get(BLACKLIST_PREFIX + token);
             if (blacklistToken != null) {
-                response.setStatus(HttpStatus.UNAUTHORIZED.value());
-                response.setContentType("application/json;charset=UTF-8");
-
-                CommonResponse<Object> objectCommonResponse = CommonResponse.of(
-                        ErrorCode.IS_BLACKLISTED, null);
-
-                String s = objectMapper.writeValueAsString(objectCommonResponse);
-                response.getWriter().write(s);
+                // 있을 때 에러 발생
+                log.info("블랙리스에 토큰 존재");
+                sendErrorCommonResponse(response, ErrorCode.IS_BLACKLISTED);
                 return;
             }
 
+            // 토큰 유효성 검사
             if (jwtUtil.validateToken(token)) {
                 Long userId = jwtUtil.getUserIdFromToken(token);
-                User user = userRepository.findById(userId).orElse(null);
+                User user = userRepository.findByIdAndIsDeletedFalse(userId).orElse(null);
 
+                // UserDetailsImpl에 로그인 된 유저 정보 저장
                 if (user != null) {
-                    UserDetailsImpl userDetails = new UserDetailsImpl(user);
+                    UserDetailsImpl userDetails = new UserDetailsImpl(user.getId(), user.getEmail(), user.getUserRole(), user.getPassword());
                     UsernamePasswordAuthenticationToken authenticationToken =
                             new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
                     SecurityContextHolder.getContext().setAuthentication(authenticationToken);
                 }
             } else {
-                response.setStatus(HttpStatus.UNAUTHORIZED.value());
-                response.setContentType("application/json;charset=UTF-8");
-
-                CommonResponse<Object> objectCommonResponse = CommonResponse.of(
-                        ErrorCode.UNAUTHORIZED_ROLE, null);
-
-                String s = objectMapper.writeValueAsString(objectCommonResponse);
-                response.getWriter().write(s);
+                // 토큰이 유효하지 않을 때 에러 발생
+                sendErrorCommonResponse(response, ErrorCode.INVALID_TOKEN);
                 return;
             }
         }
@@ -85,5 +77,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return bearer.substring(7);
         }
         return null;
+    }
+
+    // 공통 응답 형식으로 에러 보내기
+    private void sendErrorCommonResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException{
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        CommonResponse<Object> objectCommonResponse = CommonResponse.of(errorCode);
+
+        String s = objectMapper.writeValueAsString(objectCommonResponse);
+
+        response.getWriter().write(s);
     }
 }

--- a/src/main/java/caffeine/nest_dev/common/config/JwtUtil.java
+++ b/src/main/java/caffeine/nest_dev/common/config/JwtUtil.java
@@ -26,7 +26,8 @@ public class JwtUtil {
     private final SecretKey key;
     private final long accessTokenExpiration;
     private final long refreshTokenExpiration;
-    private static final String BLACKLIST_PREFIX = "blacklist:";
+    private static final String BLACKLIST_AT_PREFIX = "blacklist_AT:";
+    private static final String BLACKLIST_RT_PREFIX = "blacklist_RT:";
     private final StringRedisTemplate stringRedisTemplate;
 
     public JwtUtil(
@@ -98,12 +99,24 @@ public class JwtUtil {
         return expiration.getTime() - System.currentTimeMillis();
     }
 
-    // 토큰 블랙리스트에 추가 메서드
-    public void addToBlacklistToken(String refreshToken) {
+    // 블랙리스트에 refreshToken 추가 메서드
+    public void addToBlacklistRefreshToken(String refreshToken) {
+        log.info("블랙리스트에 토큰 추가 메서드 시작");
         long remainingExpiration = getRemainingExpiration(refreshToken);
         if (remainingExpiration > 0) {
             stringRedisTemplate.opsForValue()
-                    .set(BLACKLIST_PREFIX + refreshToken, "logout",
+                    .set(BLACKLIST_RT_PREFIX + refreshToken, "logout",
+                            Duration.ofMillis(remainingExpiration));
+        }
+    }
+
+    // 블랙리스트에 AccessToken 추가 메서드
+    public void addToBlacklistAccessToken(String accessToken) {
+        log.info("블랙리스트에 토큰 추가 메서드 시작");
+        long remainingExpiration = getRemainingExpiration(accessToken);
+        if (remainingExpiration > 0) {
+            stringRedisTemplate.opsForValue()
+                    .set(BLACKLIST_AT_PREFIX + accessToken, "logout",
                             Duration.ofMillis(remainingExpiration));
         }
     }

--- a/src/main/java/caffeine/nest_dev/common/config/SecurityConfig.java
+++ b/src/main/java/caffeine/nest_dev/common/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import caffeine.nest_dev.common.exception.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -36,7 +35,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
 //                        .requestMatchers("").hasRole("ADMIN")
                                 .requestMatchers(AUTH_WHITELIST).permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/users/{userId}").permitAll()
                                 .anyRequest().authenticated()
                 )
 

--- a/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
@@ -8,7 +8,15 @@ public enum ErrorCode implements BaseCode {
     UNAUTHORIZED_ROLE(HttpStatus.FORBIDDEN, "권한이 없는 유저입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     NO_PERMISSION(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
-    IS_BLACKLISTED(HttpStatus.UNAUTHORIZED, "로그아웃 된 토큰입니다."),
+    IS_BLACKLISTED(HttpStatus.UNAUTHORIZED, "사용할 수 없는 토큰입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "토큰이 전달되지 않았습니다."),
+    TOKEN_USER_MISMATCH(HttpStatus.UNAUTHORIZED, "토큰의 사용자 정보가 일치하지 않습니다."),
+
+    // User
+    NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "유저가 존재하지 않습니다."),
+    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 
     // Ticket
     NOT_FOUND_TICKET(HttpStatus.NOT_FOUND, "이용권이 없습니다."),
@@ -22,6 +30,9 @@ public enum ErrorCode implements BaseCode {
     // Admin 도메인 에러 예시
     ADMIN_MENTOR_CAREER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 멘토 경력 요청입니다."),
     ALREADY_SAME_STATUS(HttpStatus.CONFLICT, "이미 되어있는 상태입니다."),
+
+    // Category
+    ALREADY_EXIST_CATEGORY(HttpStatus.BAD_REQUEST, "중복된 카테고리 이름입니다.")
 
 
     ;

--- a/src/main/java/caffeine/nest_dev/common/enums/SuccessCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/SuccessCode.java
@@ -6,12 +6,14 @@ public enum SuccessCode implements BaseCode {
     // Auth
     SUCCESS_USER_LOGIN(HttpStatus.OK, "로그인을 성공하였습니다."),
     SUCCESS_USER_LOGOUT(HttpStatus.OK, "로그아웃 되었습니다."),
-    SUCCESS_USER_SIGNUP(HttpStatus.CREATED, "회원가입에 성공하였습니다."),
+    SUCCESS_USER_SIGNUP(HttpStatus.CREATED, "회원가입을 성공하였습니다."),
+    SUCCESS_REISSUE_TOKEN(HttpStatus.OK, "토큰을 재발행합니다."),
 
     // User
-    SUCCESS_FIND_USER(HttpStatus.OK, "유저 조회에 성공했습니다."),
-    SUCCESS_UPDATE_USER(HttpStatus.OK, "정보가 수정되었습니다."),
-    SUCCESS_UPDATE_PASSWORD(HttpStatus.OK, "비밀번호 변경이 성공되었습니다."),
+    SUCCESS_FIND_USER(HttpStatus.OK, "상세페이지 조회를 성공하였습니다."),
+    SUCCESS_UPDATE_USER(HttpStatus.OK, "정보 수정을 성공하였습니다.."),
+    SUCCESS_UPDATE_PASSWORD(HttpStatus.OK, "비밀번호 수정을 성공하였습니다."),
+    SUCCESS_DELETE_USER(HttpStatus.OK, "회원 탈퇴가 완료되었습니다."),
 
     // Ticket
     SUCCESS_TICKET_CREATED(HttpStatus.CREATED, "이용권에 등록을 성공하였습니다."),
@@ -32,7 +34,12 @@ public enum SuccessCode implements BaseCode {
 
     // ChatRoom
     SUCCESS_CHATROOM_CREATED(HttpStatus.CREATED, "채팅방이 생성되었습니다."),
-    SUCCESS_CHATROOM_READ(HttpStatus.OK, "채팅방 목록이 조회되었습니다.");
+    SUCCESS_CHATROOM_READ(HttpStatus.OK, "채팅방 목록이 조회되었습니다."),
+
+    // Category
+    SUCCESS_CREATE_CATEGORY(HttpStatus.CREATED, "카테고리 생성을 성공하였습니다.")
+
+    ;
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/caffeine/nest_dev/domain/auth/controller/AuthController.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/controller/AuthController.java
@@ -4,18 +4,20 @@ import caffeine.nest_dev.common.dto.CommonResponse;
 import caffeine.nest_dev.common.enums.SuccessCode;
 import caffeine.nest_dev.domain.auth.dto.request.AuthRequestDto;
 import caffeine.nest_dev.domain.auth.dto.request.LoginRequestDto;
+import caffeine.nest_dev.domain.auth.dto.request.LogoutRequestDto;
+import caffeine.nest_dev.domain.auth.dto.request.RefreshTokenRequestDto;
 import caffeine.nest_dev.domain.auth.dto.response.AuthResponseDto;
 import caffeine.nest_dev.domain.auth.dto.response.LoginResponseDto;
+import caffeine.nest_dev.domain.auth.dto.response.TokenResponseDto;
 import caffeine.nest_dev.domain.auth.service.AuthService;
-import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,17 +46,29 @@ public class AuthController {
 
         LoginResponseDto responseDto = authService.login(dto);
 
-        return ResponseEntity.ok(CommonResponse.of(SuccessCode.SUCCESS_USER_LOGIN, responseDto));
+        return ResponseEntity.ok().body(CommonResponse.of(SuccessCode.SUCCESS_USER_LOGIN, responseDto));
     }
 
     // 로그아웃
     @DeleteMapping("/logout")
     public ResponseEntity<CommonResponse<Void>> logout(
-            @AuthenticationPrincipal UserDetailsImpl userDetails
+            @RequestHeader("Authorization") String accessToken,
+            @RequestBody LogoutRequestDto dto
     ) {
 
-        authService.logout(userDetails.getId());
+        authService.logout(accessToken, dto.getRefreshToken());
 
-        return ResponseEntity.ok(CommonResponse.of(SuccessCode.SUCCESS_USER_LOGOUT, null));
+        return ResponseEntity.ok().body(CommonResponse.of(SuccessCode.SUCCESS_USER_LOGOUT));
+    }
+
+    // 토큰 재발급
+    @PostMapping("/refresh")
+    public ResponseEntity<CommonResponse<TokenResponseDto>> reissue(
+            @RequestBody RefreshTokenRequestDto dto
+    ) {
+
+        TokenResponseDto responseDto = authService.reissue(dto);
+
+        return ResponseEntity.ok().body(CommonResponse.of(SuccessCode.SUCCESS_REISSUE_TOKEN, responseDto));
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/auth/dto/request/LogoutRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/dto/request/LogoutRequestDto.java
@@ -1,0 +1,14 @@
+package caffeine.nest_dev.domain.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LogoutRequestDto {
+
+    private String refreshToken;
+
+}

--- a/src/main/java/caffeine/nest_dev/domain/auth/dto/request/RefreshTokenRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/dto/request/RefreshTokenRequestDto.java
@@ -1,0 +1,15 @@
+package caffeine.nest_dev.domain.auth.dto.request;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RefreshTokenRequestDto {
+
+    private String refreshToken;
+
+}

--- a/src/main/java/caffeine/nest_dev/domain/auth/dto/response/TokenResponseDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/dto/response/TokenResponseDto.java
@@ -1,0 +1,19 @@
+package caffeine.nest_dev.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class TokenResponseDto {
+
+    private String accessToken;
+
+    public static TokenResponseDto of(String accessToken) {
+        return TokenResponseDto.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/src/main/java/caffeine/nest_dev/domain/user/controller/UserController.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package caffeine.nest_dev.domain.user.controller;
 
 import caffeine.nest_dev.common.dto.CommonResponse;
 import caffeine.nest_dev.common.enums.SuccessCode;
+import caffeine.nest_dev.domain.auth.dto.request.RefreshTokenRequestDto;
 import caffeine.nest_dev.domain.user.dto.request.UpdatePasswordRequestDto;
 import caffeine.nest_dev.domain.user.dto.request.UserRequestDto;
 import caffeine.nest_dev.domain.user.dto.response.UserResponseDto;
@@ -11,52 +12,66 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users")
+@RequestMapping("/api/users/me")
 public class UserController {
 
     private final UserService userService;
 
     // 마이페이지 조회
-    @GetMapping("/{userId}")
+    @GetMapping()
     public ResponseEntity<CommonResponse<UserResponseDto>> getUser(
-            @PathVariable Long userId
+            @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
 
-        UserResponseDto dto = userService.findById(userId);
+        UserResponseDto dto = userService.findUser(userDetails.getId());
 
         return ResponseEntity.ok().body(CommonResponse.of(SuccessCode.SUCCESS_FIND_USER, dto));
     }
 
     // 정보 수정
-    @PatchMapping("/me")
+    @PatchMapping()
     public ResponseEntity<CommonResponse<Void>> updateUser(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Valid @RequestBody UserRequestDto dto
     ) {
 
-        userService.updateUser(userDetails.getUser(), dto);
+        userService.updateUser(userDetails.getId(), dto);
 
-        return ResponseEntity.ok(CommonResponse.of(SuccessCode.SUCCESS_UPDATE_USER, null));
+        return ResponseEntity.ok().body(CommonResponse.of(SuccessCode.SUCCESS_UPDATE_USER));
     }
 
     // 비밀번호 수정
-    @PatchMapping("/me/password")
+    @PatchMapping("/password")
     public ResponseEntity<CommonResponse<Void>> updatePassword(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Valid @RequestBody UpdatePasswordRequestDto dto
     ) {
 
-        userService.updatePassword(userDetails.getUser(), dto);
+        userService.updatePassword(userDetails.getId(), dto);
 
-        return ResponseEntity.ok(CommonResponse.of(SuccessCode.SUCCESS_UPDATE_PASSWORD, null));
+        return ResponseEntity.ok().body(CommonResponse.of(SuccessCode.SUCCESS_UPDATE_PASSWORD));
+    }
+
+    // 회원 탈퇴
+    @DeleteMapping()
+    public ResponseEntity<CommonResponse<Void>> deleteUser(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestHeader("Authorization") String accessToken,
+            @RequestBody RefreshTokenRequestDto dto
+    ) {
+
+        userService.deleteUser(userDetails.getId(), accessToken, dto.getRefreshToken());
+
+        return ResponseEntity.ok().body(CommonResponse.of(SuccessCode.SUCCESS_DELETE_USER));
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/user/entity/User.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package caffeine.nest_dev.domain.user.entity;
 
 import caffeine.nest_dev.common.entity.BaseEntity;
+import caffeine.nest_dev.domain.user.dto.request.UserRequestDto;
 import caffeine.nest_dev.domain.user.enums.SocialType;
 import caffeine.nest_dev.domain.user.enums.UserGrade;
 import caffeine.nest_dev.domain.user.enums.UserRole;
@@ -61,29 +62,38 @@ public class User extends BaseEntity {
     @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private boolean isDeleted;
 
-    public void updateEmail(String email) {
-        this.email = email;
-    }
-
     // -------------- 수정 메서드 --------------
 
-    public void updateNickName(String nickName) {
-        this.nickName = nickName;
-    }
+    public void updateUser(UserRequestDto dto, User user) {
+        if (dto.getEmail() != null) {
+            this.email = dto.getEmail();
+        }
 
-    public void updatePhoneNumber (String phoneNumber) {
-        this.phoneNumber = phoneNumber;
-    }
+        if (dto.getNickName() != null) {
+            this.nickName = dto.getNickName();
+        }
 
-    public void updateBank(String bank) {
-        this.bank = bank;
-    }
+        if (dto.getPhoneNumber() != null) {
+            this.phoneNumber = dto.getPhoneNumber();
+        }
 
-    public void updateAccountNumber(String accountNumber) {
-        this.accountNumber = accountNumber;
+        // 멘토일 경우 추가 수정
+        if (user.getUserRole() == UserRole.MENTOR) {
+            if (dto.getBank() != null) {
+                this.bank = dto.getBank();
+            }
+
+            if (dto.getAccountNumber() != null) {
+                this.accountNumber = dto.getAccountNumber();
+            }
+        }
     }
 
     public void updatePassword(String password) {
         this.password = password;
+    }
+
+    public void deleteUser(boolean isDeleted) {
+        this.isDeleted = isDeleted;
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/user/entity/UserDetailsImpl.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/entity/UserDetailsImpl.java
@@ -12,20 +12,20 @@ import org.springframework.security.core.userdetails.UserDetails;
 @Getter
 public class UserDetailsImpl implements UserDetails, CredentialsContainer { // Spring security 에서 인증이 끝나면 eraseCredentials() 를 자동으로 호출
 
-    private final Long userId;
+    private final Long id;
     private final String email;
     private final UserRole userRole;
     private String password;
 
-    public UserDetailsImpl(Long userId, String email, UserRole userRole, String password) {
-        this.userId = userId;
+    public UserDetailsImpl(Long id, String email, UserRole userRole, String password) {
+        this.id = id;
         this.email = email;
         this.userRole = userRole;
         this.password = password;
     }
 
     public Long getId() {
-        return userId;
+        return id;
     }
 
 

--- a/src/main/java/caffeine/nest_dev/domain/user/entity/UserDetailsImpl.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/entity/UserDetailsImpl.java
@@ -1,43 +1,48 @@
 package caffeine.nest_dev.domain.user.entity;
 
+import caffeine.nest_dev.domain.user.enums.UserRole;
 import java.util.Collection;
 import java.util.List;
 import lombok.Getter;
+import org.springframework.security.core.CredentialsContainer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
-public class UserDetailsImpl implements UserDetails {
+public class UserDetailsImpl implements UserDetails, CredentialsContainer { // Spring security 에서 인증이 끝나면 eraseCredentials() 를 자동으로 호출
 
-    private final User user;
+    private final Long userId;
+    private final String email;
+    private final UserRole userRole;
+    private String password;
 
-    public UserDetailsImpl(User user) {
-        this.user = user;
+    public UserDetailsImpl(Long userId, String email, UserRole userRole, String password) {
+        this.userId = userId;
+        this.email = email;
+        this.userRole = userRole;
+        this.password = password;
     }
 
     public Long getId() {
-        return user.getId();
+        return userId;
     }
 
-    public User getUser() {
-        return user;
-    }
 
     // UserRole enum을 문자열로 변환
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getUserRole().name()));
+        return List.of(new SimpleGrantedAuthority("ROLE_" + userRole.name()));
     }
 
     @Override
     public String getPassword() {
-        return user.getPassword();
+        return password;
     }
 
     @Override
     public String getUsername() {
-        return user.getEmail();
+        return email;
     }
 
     // true를 직접 반환하는 것이 더 명확! (가독성을 위해)
@@ -59,5 +64,12 @@ public class UserDetailsImpl implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+
+    // 인증이 끝난 뒤에는 즉시 메모리에서 지우는 것이 보안상 권장되는 방식
+    @Override
+    public void eraseCredentials() {
+        this.password = null;
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/user/repository/UserRepository.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/repository/UserRepository.java
@@ -1,15 +1,19 @@
 package caffeine.nest_dev.domain.user.repository;
 
+import caffeine.nest_dev.common.enums.ErrorCode;
+import caffeine.nest_dev.common.exception.BaseException;
 import caffeine.nest_dev.domain.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByEmail(String email);
+    Optional<User> findByEmailAndIsDeletedFalse(String email);
+
+    Optional<User> findByIdAndIsDeletedFalse(Long userId);
 
     default User findByIdOrElseThrow(Long userId) {
-        return findById(userId).orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+        return findById(userId).orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER));
     }
 
     boolean existsByEmail(String email);

--- a/src/main/java/caffeine/nest_dev/domain/user/service/UserService.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/service/UserService.java
@@ -1,25 +1,30 @@
 package caffeine.nest_dev.domain.user.service;
 
+import caffeine.nest_dev.common.config.JwtUtil;
 import caffeine.nest_dev.common.config.PasswordEncoder;
+import caffeine.nest_dev.common.enums.ErrorCode;
+import caffeine.nest_dev.common.exception.BaseException;
 import caffeine.nest_dev.domain.user.dto.request.UpdatePasswordRequestDto;
 import caffeine.nest_dev.domain.user.dto.request.UserRequestDto;
 import caffeine.nest_dev.domain.user.dto.response.UserResponseDto;
 import caffeine.nest_dev.domain.user.entity.User;
-import caffeine.nest_dev.domain.user.enums.UserRole;
 import caffeine.nest_dev.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
 
     @Transactional(readOnly = true)
-    public UserResponseDto findById(Long userId) {
+    public UserResponseDto findUser(Long userId) {
 
         // 유저 조회
         User user = userRepository.findByIdOrElseThrow(userId);
@@ -28,51 +33,34 @@ public class UserService {
     }
 
     @Transactional
-    public void updateUser(User user, UserRequestDto dto) {
+    public void updateUser(Long userId, UserRequestDto dto) {
 
         // dto 가 null 일 때
         if (dto == null) {
             throw new IllegalArgumentException("수정하려는 항목 중 하나는 필수 입력값입니다.");
         }
 
-        if (dto.getEmail() != null) {
-            // 이메일 중복 검증
-            if (userRepository.existsByEmail(dto.getEmail())) {
-                throw new IllegalArgumentException("중복된 이메일 입니다.");
-            }
-
-            user.updateEmail(dto.getEmail());
+        // 이메일 중복 검증
+        if (userRepository.existsByEmail(dto.getEmail())) {
+            throw new BaseException(ErrorCode.ALREADY_EXIST_EMAIL);
         }
 
-        if (dto.getNickName() != null) {
-            user.updateNickName(dto.getNickName());
-        }
+        // 유저 조회
+        User user = userRepository.findByIdOrElseThrow(userId);
 
-        if (dto.getPhoneNumber() != null) {
-            user.updatePhoneNumber(dto.getPhoneNumber());
-        }
-
-        // 멘토일 경우 추가 수정
-        if (user.getUserRole() == UserRole.MENTOR) {
-            if (dto.getBank() != null) {
-                user.updateBank(dto.getBank());
-            }
-
-            if (dto.getAccountNumber() != null) {
-                user.updateAccountNumber(dto.getAccountNumber());
-            }
-        }
-
-        // 바꾼 유저 정보 바탕으로 저장
-        userRepository.save(user);
+        // 수정 메서드 호출
+        user.updateUser(dto, user);
     }
 
     @Transactional
-    public void updatePassword(User user, UpdatePasswordRequestDto dto) {
+    public void updatePassword(Long userId, UpdatePasswordRequestDto dto) {
+
+        // 유저 조회
+        User user = userRepository.findByIdOrElseThrow(userId);
 
         // 비밀 번호 검증
         if (!passwordEncoder.matches(dto.getRawPassword(), user.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new BaseException(ErrorCode.INVALID_PASSWORD);
         }
 
         // 새로운 비밀번호가 현재 비밀번호와 같은 경우
@@ -83,8 +71,44 @@ public class UserService {
         // 새 비밀번호 인코딩
         String encodedPassword = passwordEncoder.encode(dto.getNewPassword());
 
-        // 바꾼 비밀번호 저장
+        // 비밀번호 변경
         user.updatePassword(encodedPassword);
-        userRepository.save(user);
+    }
+
+    @Transactional
+    public void deleteUser(Long userId, String accessToken, String refreshToken) {
+
+        // 토큰 무효화
+        if (refreshToken == null) {
+            throw new BaseException(ErrorCode.TOKEN_MISSING);
+        }
+
+        // refresh 토큰 유효성 검사
+        log.info("토큰 유효성 검사 시작");
+        if (jwtUtil.validateToken(refreshToken)) {
+            throw new BaseException(ErrorCode.INVALID_TOKEN);
+        }
+
+        // access 토큰에서 가져온 userId 와 refresh 토큰에서 가져온 userId 가 일치하는지 검증
+        Long userIdFromAccessToken = jwtUtil.getUserIdFromToken(accessToken);
+        Long userIdFromRefreshToken = jwtUtil.getUserIdFromToken(refreshToken);
+        if (!userIdFromAccessToken.equals(userIdFromRefreshToken)) {
+            throw new BaseException(ErrorCode.TOKEN_USER_MISMATCH);
+        }
+
+        // 유저 조회
+        User user = userRepository.findByIdOrElseThrow(userId);
+
+
+        // access 토큰 redis에 블랙리스트 추가
+        jwtUtil.addToBlacklistAccessToken(accessToken);
+        log.info("access 토큰을 블랙리스트에 추가");
+
+        // refresh 토큰 redis에 블랙리스트 추가
+        jwtUtil.addToBlacklistRefreshToken(refreshToken);
+        log.info("refresh 토큰을 블랙리스트에 추가");
+
+        // 유저 상태 변경
+        user.deleteUser(true);
     }
 }


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
> creates #25 
>
> **제목 예시:** `feat : Pull request template 작성`
>
> (✅ 작성 후 이 안내 문구는 삭제해주세요)
>

---

## 🔎 작업 내용

- 어떤 기능(또는 수정 사항)을 구현했는지 간략하게 설명해주세요.
- 예) "회원가입 API에 이메일 중복 검사 기능 추가"

---

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
  - `UserService.createUser()` 메서드 추가
  - `@Email` 유효성 검증 적용

--- 회원 탈퇴 기능 구현 및 로그아웃
--- User 객체 저장에서 필요한 값만 저장 하는 방식으로 변경(비밀번호는 인증 이후 삭제되도록 설계)
## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

--- 

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인