### PR TITLE
[#26] feat: 유저 쿠폰 생성, 조회, 수정 기능 구현

### DIFF
--- a/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
@@ -32,6 +32,12 @@ public enum ErrorCode implements BaseCode {
 
     // AdminCoupon
     NOT_FOUND_ADMIN_COUPON(HttpStatus.NOT_FOUND, "쿠폰이 없습니다."),
+    COUPON_QUANTITY_NOT_SET(HttpStatus.INTERNAL_SERVER_ERROR, "쿠폰 수량 정보가 존재하지 않습니다."),
+    COUPON_OUT_OF_STOCK(HttpStatus.CONFLICT, "쿠폰이 모두 소진되었습니다."),
+    NOT_FOUND_COUPON(HttpStatus.NOT_FOUND, "존재하지 않는 쿠폰입니다."),
+
+    // UserCoupon
+    NOT_FOUND_USER_COUPON(HttpStatus.NOT_FOUND, "보유하신 쿠폰이 없습니다."),
 
     // SERVER_ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),

--- a/src/main/java/caffeine/nest_dev/common/enums/SuccessCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/SuccessCode.java
@@ -27,6 +27,11 @@ public enum SuccessCode implements BaseCode {
     SUCCESS_ADMIN_COUPON_UPDATED(HttpStatus.OK, "쿠폰이 수정되었습니다."),
     SUCCESS_ADMIN_COUPON_DELETED(HttpStatus.NO_CONTENT, "쿠폰이 삭제되었습니다."),
 
+    // UserCoupon
+    SUCCESS_USER_COUPON_CREATED(HttpStatus.CREATED, "쿠폰 발급이 완료되었습니다."),
+    SUCCESS_USER_COUPON_READ(HttpStatus.OK, "목록을 조회 완료하였습니다."),
+    SUCCESS_USER_COUPON_UPDATED(HttpStatus.OK, "쿠폰이 사용되었습니다."),
+
     // Admin
     SUCCESS_ADMIN_MENTOR_CAREER_READ(HttpStatus.OK, "멘토 경력 확인 요청 목록을 조회하였습니다."),
     SUCCESS_ADMIN_MENTOR_CAREER_DETAIL_READ(HttpStatus.OK, "관리자 멘토 경력 단건 조회 성공"),

--- a/src/main/java/caffeine/nest_dev/domain/coupon/controller/UserCouponController.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/controller/UserCouponController.java
@@ -49,7 +49,7 @@ public class UserCouponController {
     public ResponseEntity<CommonResponse<Void>> updateUseUserCoupon(
             @RequestBody UserCouponRequestDto requestDto
     ) {
-        userCouponService.modifyUseCoupon(requestDto);
+        userCouponService.modifyUserCoupon(requestDto);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_USER_COUPON_UPDATED));
     }

--- a/src/main/java/caffeine/nest_dev/domain/coupon/controller/UserCouponController.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/controller/UserCouponController.java
@@ -1,0 +1,56 @@
+package caffeine.nest_dev.domain.coupon.controller;
+
+import caffeine.nest_dev.common.dto.CommonResponse;
+import caffeine.nest_dev.common.dto.PagingResponse;
+import caffeine.nest_dev.common.enums.SuccessCode;
+import caffeine.nest_dev.domain.coupon.dto.request.UserCouponRequestDto;
+import caffeine.nest_dev.domain.coupon.dto.response.UserCouponResponseDto;
+import caffeine.nest_dev.domain.coupon.service.UserCouponService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user-coupons")
+public class UserCouponController {
+
+    private final UserCouponService userCouponService;
+
+    @PostMapping
+    public ResponseEntity<CommonResponse<UserCouponResponseDto>> registerUserCoupon(
+            @RequestBody UserCouponRequestDto requestDto) {
+        UserCouponResponseDto responseDto = userCouponService.saveUserCoupon(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.of(SuccessCode.SUCCESS_USER_COUPON_CREATED, responseDto));
+    }
+
+    @GetMapping
+    public ResponseEntity<CommonResponse<PagingResponse<UserCouponResponseDto>>> findUserCoupons(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        PagingResponse<UserCouponResponseDto> responseDtos = userCouponService.getUserCoupon(pageable);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of(SuccessCode.SUCCESS_USER_COUPON_READ, responseDtos));
+    }
+
+    @PatchMapping("/use")
+    public ResponseEntity<CommonResponse<Void>> updateUseUserCoupon(
+            @RequestBody UserCouponRequestDto requestDto
+    ) {
+        userCouponService.modifyUseCoupon(requestDto);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of(SuccessCode.SUCCESS_USER_COUPON_UPDATED));
+    }
+}

--- a/src/main/java/caffeine/nest_dev/domain/coupon/dto/request/UserCouponRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/dto/request/UserCouponRequestDto.java
@@ -1,0 +1,26 @@
+package caffeine.nest_dev.domain.coupon.dto.request;
+
+import caffeine.nest_dev.domain.coupon.entity.Coupon;
+import caffeine.nest_dev.domain.coupon.entity.UserCoupon;
+import caffeine.nest_dev.domain.coupon.entity.UserCouponId;
+import caffeine.nest_dev.domain.coupon.enums.CouponUseStatus;
+import caffeine.nest_dev.domain.user.entity.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserCouponRequestDto {
+    private Long couponId;
+    private Long userId;
+    private CouponUseStatus useStatus;
+
+    public UserCoupon toEntity(Coupon coupon, User user) {
+        return UserCoupon.builder()
+                .id(new UserCouponId(coupon.getId(), user.getId()))
+                .coupon(coupon)
+                .user(user)
+                .isUsed(useStatus)
+                .build();
+    }
+}

--- a/src/main/java/caffeine/nest_dev/domain/coupon/dto/response/AdminCouponResponseDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/dto/response/AdminCouponResponseDto.java
@@ -21,6 +21,7 @@ public class AdminCouponResponseDto {
     private final LocalDateTime validFrom;
     private final LocalDateTime validTo;
     private final UserGrade minGrade;
+    private final boolean canIssue;
 
     public static AdminCouponResponseDto of(Coupon coupon) {
         return AdminCouponResponseDto.builder()
@@ -32,6 +33,7 @@ public class AdminCouponResponseDto {
                 .validFrom(coupon.getValidFrom())
                 .validTo(coupon.getValidTo())
                 .minGrade(coupon.getMinGrade())
+                .canIssue(coupon.canIssue())
                 .build();
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/coupon/dto/response/UserCouponResponseDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/dto/response/UserCouponResponseDto.java
@@ -1,0 +1,25 @@
+package caffeine.nest_dev.domain.coupon.dto.response;
+
+import caffeine.nest_dev.domain.coupon.entity.UserCoupon;
+import caffeine.nest_dev.domain.coupon.enums.CouponUseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserCouponResponseDto {
+
+    private final Long couponId;
+    private final Long userId;
+    private final CouponUseStatus useStatus;
+
+    public static UserCouponResponseDto of(UserCoupon userCoupon) {
+        return UserCouponResponseDto.builder()
+                .couponId(userCoupon.getId().getCouponId())
+                .userId(userCoupon.getId().getUserId())
+                .useStatus(userCoupon.getIsUsed())
+                .build();
+    }
+}

--- a/src/main/java/caffeine/nest_dev/domain/coupon/entity/Coupon.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/entity/Coupon.java
@@ -1,5 +1,7 @@
 package caffeine.nest_dev.domain.coupon.entity;
 
+import caffeine.nest_dev.common.enums.ErrorCode;
+import caffeine.nest_dev.common.exception.BaseException;
 import caffeine.nest_dev.domain.coupon.dto.request.AdminCouponRequestDto;
 import caffeine.nest_dev.domain.user.enums.UserGrade;
 import jakarta.persistence.*;
@@ -62,5 +64,26 @@ public class Coupon {
         if (requestDto.getMinGrade() != null) {
             this.minGrade = requestDto.getMinGrade();
         }
+    }
+
+    public void issue() {
+        if (this.totalQuantity == null || this.issuedQuantity == null) {
+            throw new BaseException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+        if (this.totalQuantity <= 0) {
+            throw new BaseException(ErrorCode.COUPON_OUT_OF_STOCK);
+        }
+        if (this.issuedQuantity + 1 > this.totalQuantity) {
+            throw new BaseException(ErrorCode.COUPON_OUT_OF_STOCK);
+        }
+        this.totalQuantity -= 1;
+        this.issuedQuantity += 1;
+    }
+
+    public boolean canIssue() {
+        return this.totalQuantity != null
+                && this.issuedQuantity != null
+                && this.totalQuantity > 0
+                && this.issuedQuantity < this.totalQuantity;
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/coupon/entity/UserCoupon.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/entity/UserCoupon.java
@@ -1,6 +1,7 @@
 package caffeine.nest_dev.domain.coupon.entity;
 
 import caffeine.nest_dev.common.entity.BaseEntity;
+import caffeine.nest_dev.domain.coupon.dto.request.UserCouponRequestDto;
 import caffeine.nest_dev.domain.coupon.enums.CouponUseStatus;
 import caffeine.nest_dev.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -29,4 +30,10 @@ public class UserCoupon extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private CouponUseStatus isUsed;
+
+    public void modifyUseStatus(UserCouponRequestDto requestDto) {
+        if (requestDto.getUseStatus() != null) {
+            this.isUsed = requestDto.getUseStatus();
+        }
+    }
 }

--- a/src/main/java/caffeine/nest_dev/domain/coupon/entity/UserCouponId.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/entity/UserCouponId.java
@@ -18,5 +18,9 @@ public class UserCouponId implements Serializable {
     @Column(name = "user_id")
     private Long userId;
 
+    public UserCouponId(Long couponId, Long userId) {
+        this.couponId = couponId;
+        this.userId = userId;
+    }
 }
 

--- a/src/main/java/caffeine/nest_dev/domain/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/repository/UserCouponRepository.java
@@ -2,9 +2,13 @@ package caffeine.nest_dev.domain.coupon.repository;
 
 import caffeine.nest_dev.domain.coupon.entity.Coupon;
 import caffeine.nest_dev.domain.coupon.entity.UserCoupon;
+import caffeine.nest_dev.domain.coupon.entity.UserCouponId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
-public interface UserCouponRepository extends CrudRepository<UserCoupon, Long> {
+public interface UserCouponRepository extends CrudRepository<UserCoupon, UserCouponId> {
     // FK로 묶인 user_coupon 먼저 삭제
     void deleteByCoupon(Coupon coupon);
+    Page<UserCoupon> findAll(Pageable pageable);
 }

--- a/src/main/java/caffeine/nest_dev/domain/coupon/service/AdminCouponService.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/service/AdminCouponService.java
@@ -10,7 +10,6 @@ import caffeine.nest_dev.domain.coupon.repository.AdminCouponRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/caffeine/nest_dev/domain/coupon/service/UserCouponService.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/service/UserCouponService.java
@@ -46,7 +46,7 @@ public class UserCouponService {
     }
 
     @Transactional
-    public void modifyUseCoupon(UserCouponRequestDto requestDto) {
+    public void modifyUserCoupon(UserCouponRequestDto requestDto) {
         UserCouponId userCouponId = new UserCouponId(requestDto.getCouponId(), requestDto.getUserId());
         UserCoupon userCoupon = userCouponRepository.findById(userCouponId)
                 .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER_COUPON));

--- a/src/main/java/caffeine/nest_dev/domain/coupon/service/UserCouponService.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/service/UserCouponService.java
@@ -1,0 +1,55 @@
+package caffeine.nest_dev.domain.coupon.service;
+
+import caffeine.nest_dev.common.dto.PagingResponse;
+import caffeine.nest_dev.common.enums.ErrorCode;
+import caffeine.nest_dev.common.exception.BaseException;
+import caffeine.nest_dev.domain.coupon.dto.request.UserCouponRequestDto;
+import caffeine.nest_dev.domain.coupon.dto.response.UserCouponResponseDto;
+import caffeine.nest_dev.domain.coupon.entity.Coupon;
+import caffeine.nest_dev.domain.coupon.entity.UserCoupon;
+import caffeine.nest_dev.domain.coupon.entity.UserCouponId;
+import caffeine.nest_dev.domain.coupon.repository.AdminCouponRepository;
+import caffeine.nest_dev.domain.coupon.repository.UserCouponRepository;
+import caffeine.nest_dev.domain.user.entity.User;
+import caffeine.nest_dev.domain.user.repository.UserRepository;
+import caffeine.nest_dev.domain.user.service.UserService;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserCouponService {
+
+    private final UserCouponRepository userCouponRepository;
+    private final AdminCouponRepository adminCouponRepository;
+    private final UserService userService;
+
+    @Transactional
+    public UserCouponResponseDto saveUserCoupon(UserCouponRequestDto requestDto) {
+        Coupon coupon = adminCouponRepository.findById(requestDto.getCouponId())
+                .orElseThrow(() -> new BaseException(
+                        ErrorCode.NOT_FOUND_USER_COUPON));
+        User user = userService.findByIdAndIsDeletedFalseOrElseThrow(requestDto.getUserId());
+        coupon.issue();
+        UserCoupon userCoupon = userCouponRepository.save(requestDto.toEntity(coupon, user));
+        return UserCouponResponseDto.of(userCoupon);
+    }
+
+    @Transactional(readOnly = true)
+    public PagingResponse<UserCouponResponseDto> getUserCoupon(Pageable pageable) {
+        Page<UserCoupon> pagingResponse = userCouponRepository.findAll(pageable);
+        Page<UserCouponResponseDto> responseDtos = pagingResponse.map(UserCouponResponseDto::of);
+        return PagingResponse.from(responseDtos);
+    }
+
+    @Transactional
+    public void modifyUseCoupon(UserCouponRequestDto requestDto) {
+        UserCouponId userCouponId = new UserCouponId(requestDto.getCouponId(), requestDto.getUserId());
+        UserCoupon userCoupon = userCouponRepository.findById(userCouponId)
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER_COUPON));
+        userCoupon.modifyUseStatus(requestDto);
+    }
+}


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
> closes #26
>
>

--- feat: 유저 쿠폰 생성, 조회, 수정 기능 구현

## 🔎 작업 내용

- 어떤 기능(또는 수정 사항)을 구현했는지 간략하게 설명해주세요.
- 예) "회원가입 API에 이메일 중복 검사 기능 추가"

- 유저 쿠폰 생성
- 유저 쿠폰 조회
- 유저 쿠폰 수정
- 유저 쿠폰 발급 시 관리자 쿠폰 전체 수량 및 현재 발급된 수량 체크
- 관리자 쿠폰 발급 여부 확인
- 유저 쿠폰 만료 기간 자동 삭제 기능 적용

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
  - `UserService.createUser()` 메서드 추가
  - `@Email` 유효성 검증 적용

- 유저 쿠폰 발급 시 관리자 쿠폰 전체 수량 및 현재 발급된 수량 체크
- 유저 쿠폰 만료 기간 자동 삭제 기능 적용

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

- 동시성 문제 해결

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인