### PR TITLE
refactor: 유저 쿠폰 사용 여부 DB 반영 안된 부분 수정

### DIFF
--- a/src/main/java/caffeine/nest_dev/domain/coupon/dto/request/UserCouponRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/dto/request/UserCouponRequestDto.java
@@ -13,14 +13,14 @@ import lombok.NoArgsConstructor;
 public class UserCouponRequestDto {
     private Long couponId;
     private Long userId;
-    private CouponUseStatus useStatus;
+    private CouponUseStatus isUsed;
 
     public UserCoupon toEntity(Coupon coupon, User user) {
         return UserCoupon.builder()
                 .id(new UserCouponId(coupon.getId(), user.getId()))
                 .coupon(coupon)
                 .user(user)
-                .isUsed(useStatus)
+                .isUsed(isUsed)
                 .build();
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/coupon/entity/UserCoupon.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/entity/UserCoupon.java
@@ -32,8 +32,8 @@ public class UserCoupon extends BaseEntity {
     private CouponUseStatus isUsed;
 
     public void modifyUseStatus(UserCouponRequestDto requestDto) {
-        if (requestDto.getUseStatus() != null) {
-            this.isUsed = requestDto.getUseStatus();
+        if (requestDto.getIsUsed() != null) {
+            this.isUsed = requestDto.getIsUsed();
         }
     }
 }


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
> closes #44
>
>

- 유저 쿠폰 사용 여부 DB 반영 사항

## 🔎 작업 내용

- 어떤 기능(또는 수정 사항)을 구현했는지 간략하게 설명해주세요.
- 예) "회원가입 API에 이메일 중복 검사 기능 추가"

- 유저 쿠폰 사용 여부 DB 반영 안된 부분 수정

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
  - `UserService.createUser()` 메서드 추가
  - `@Email` 유효성 검증 적용

- Request useStatus -> isUsed로 변경

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

- request 전달 시 네이밍이 맞지 않아서 db 반영이 안된 상태

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인