### PR TITLE
[#60] Feat : 1대1 채팅 구현

### DIFF
--- a/src/main/java/caffeine/nest_dev/common/config/WebSocketConfig.java
+++ b/src/main/java/caffeine/nest_dev/common/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package caffeine.nest_dev.common.config;
 
+import caffeine.nest_dev.domain.websocket.util.ChatHandshakeHandler;
 import caffeine.nest_dev.domain.websocket.util.WebSocketAuthInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +21,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
      * 웹소켓 연결 시 인증을 위한 HandShake 인터셉터
      */
     private final WebSocketAuthInterceptor webSocketAuthInterceptor;
+    private final ChatHandshakeHandler chatHandshakeHandler;
 
     /**
      * STOMP 엔드포인트 등록 해당 엔드포인트로 웹소켓 연결
@@ -31,6 +33,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws-nest") // handshake 를 위해(최초 연결 시) 연결하는 endpoint
                 .addInterceptors(webSocketAuthInterceptor) // socket 연결 전 인증, 검증 로직 수행
                 .setAllowedOriginPatterns("*")  // cors 설정 (허용할 origin 지정)
+                .setHandshakeHandler(chatHandshakeHandler)
                 .withSockJS();  // 웹소켓을 지원하지 않는 브라우저도 사용할 수 있는 대체 옵션 지정
     }
 

--- a/src/main/java/caffeine/nest_dev/domain/message/controller/MessageController.java
+++ b/src/main/java/caffeine/nest_dev/domain/message/controller/MessageController.java
@@ -2,9 +2,11 @@ package caffeine.nest_dev.domain.message.controller;
 
 import caffeine.nest_dev.domain.message.dto.request.MessageRequestDto;
 import caffeine.nest_dev.domain.message.service.MessageService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
 
 @Controller
@@ -19,8 +21,10 @@ public class MessageController {
     @MessageMapping("/chat_room/{chatRoomId}/message")
     public void chat(
             @DestinationVariable Long chatRoomId,
-            MessageRequestDto requestDto) {
+            Principal principal,
+            @Payload MessageRequestDto requestDto) {
 
-        messageService.sendMessage(chatRoomId, requestDto);
+        long userId = Long.parseLong(principal.getName());
+        messageService.sendMessage(chatRoomId, userId, requestDto);
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/message/controller/MessageController.java
+++ b/src/main/java/caffeine/nest_dev/domain/message/controller/MessageController.java
@@ -4,11 +4,13 @@ import caffeine.nest_dev.domain.message.dto.request.MessageRequestDto;
 import caffeine.nest_dev.domain.message.service.MessageService;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class MessageController {
@@ -25,6 +27,7 @@ public class MessageController {
             @Payload MessageRequestDto requestDto) {
 
         long userId = Long.parseLong(principal.getName());
+        log.info("메시지 보내는 userId : {}", userId);
         messageService.sendMessage(chatRoomId, userId, requestDto);
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/message/dto/request/MessageRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/message/dto/request/MessageRequestDto.java
@@ -2,7 +2,6 @@ package caffeine.nest_dev.domain.message.dto.request;
 
 import caffeine.nest_dev.domain.chatroom.entity.ChatRoom;
 import caffeine.nest_dev.domain.message.entity.Message;
-import caffeine.nest_dev.domain.reservation.entity.Reservation;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,16 +11,11 @@ import lombok.Setter;
 @NoArgsConstructor
 public class MessageRequestDto {
 
-    private Long roomId;
-    private Long reservationId;
-    private Long senderId;
-    private Long receiverId;
     private String content;
 
-    public Message toEntity(ChatRoom chatRoom, Reservation reservation) {
+    public Message toEntity(ChatRoom chatRoom) {
         return Message.builder()
-                .chatRoom(chatRoom)
-                .reservation(reservation)
+                .reservation(chatRoom.getReservation())
                 .mentor(chatRoom.getMentor())
                 .mentee(chatRoom.getMentee())
                 .content(this.getContent())

--- a/src/main/java/caffeine/nest_dev/domain/message/dto/request/MessageRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/message/dto/request/MessageRequestDto.java
@@ -15,6 +15,7 @@ public class MessageRequestDto {
 
     public Message toEntity(ChatRoom chatRoom) {
         return Message.builder()
+                .chatRoom(chatRoom)
                 .reservation(chatRoom.getReservation())
                 .mentor(chatRoom.getMentor())
                 .mentee(chatRoom.getMentee())

--- a/src/main/java/caffeine/nest_dev/domain/message/service/MessageService.java
+++ b/src/main/java/caffeine/nest_dev/domain/message/service/MessageService.java
@@ -9,8 +9,6 @@ import caffeine.nest_dev.domain.message.dto.request.MessageRequestDto;
 import caffeine.nest_dev.domain.message.dto.response.MessageResponseDto;
 import caffeine.nest_dev.domain.message.entity.Message;
 import caffeine.nest_dev.domain.message.repository.MessageRepository;
-import caffeine.nest_dev.domain.reservation.entity.Reservation;
-import caffeine.nest_dev.domain.reservation.repository.ReservationRepository;
 import caffeine.nest_dev.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -23,54 +21,41 @@ public class MessageService {
 
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final ChatRoomRepository chatRoomRepository;
-    private final ReservationRepository reservationRepository;
     private final MessageRepository messageRepository;
 
-    // TODO :  인증 절차 도입 후 수정
     @Transactional
-    public void sendMessage(Long chatRoomId, MessageRequestDto requestDto) {
+    public void sendMessage(Long chatRoomId, Long userId, MessageRequestDto requestDto) {
 
         try {
 
             ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow(
                     () -> new BaseException(ErrorCode.CHATROOM_NOT_FOUND)
             );
-            Reservation reservation = reservationRepository.findById(requestDto.getReservationId()).orElseThrow(
-                    () -> new BaseException(ErrorCode.RESERVATION_NOT_FOUND)
-            );
 
-            // sender / receiver 식별
-            Long senderId = requestDto.getSenderId();
-
-            boolean isMentorSender = chatRoom.getMentor().getId().equals(senderId);
+            boolean isMentorSender = chatRoom.getMentor().getId().equals(userId);
             User sender = isMentorSender ? chatRoom.getMentor() : chatRoom.getMentee();
             User receiver = isMentorSender ? chatRoom.getMentee() : chatRoom.getMentor();
 
             // 메시지 생성, 저장
-            Message message = requestDto.toEntity(chatRoom, reservation);
+            Message message = requestDto.toEntity(chatRoom);
             messageRepository.save(message);
 
             MessageResponseDto messageResponseDto = MessageResponseDto.of(message, sender, receiver);
 
-            // 메시지 전송 (구독 경로, 보낼 메시지)
-            // 구독한 모든 클라이언트에게 브로드캐스트
-            simpMessagingTemplate.convertAndSend(
-                    "/topic/chat_room/" + chatRoomId,
+            // 메시지 전송 (수신자, 구독 경로, 보낼 메시지)
+            simpMessagingTemplate.convertAndSendToUser(
+                    String.valueOf(receiver.getId()),
+                    "/queue/message",
                     messageResponseDto
             );
         } catch (BaseException e) {
-            simpMessagingTemplate.convertAndSend(
-                    "/queue/error/" + requestDto.getSenderId(),
+            simpMessagingTemplate.convertAndSendToUser(
+                    String.valueOf(userId),
+                    "/queue/error/",
                     CommonResponse.of(e.getErrorCode())
             );
 
         }
 
-//        // 메시지 전송 (수신자, 구독 경로, 보낼 메시지)
-//        simpMessagingTemplate.convertAndSendToUser(
-//                String.valueOf(receiver.getId()),
-//                "/queue/message",
-//                messageResponseDto
-//        );
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/websocket/util/ChatHandshakeHandler.java
+++ b/src/main/java/caffeine/nest_dev/domain/websocket/util/ChatHandshakeHandler.java
@@ -1,0 +1,22 @@
+package caffeine.nest_dev.domain.websocket.util;
+
+import com.sun.security.auth.UserPrincipal;
+import java.security.Principal;
+import java.util.Map;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+@Component
+public class ChatHandshakeHandler extends DefaultHandshakeHandler {
+
+    @Override
+    protected Principal determineUser(ServerHttpRequest request,
+            WebSocketHandler wsHandler,
+            Map<String, Object> attributes) {
+
+        Object userId = attributes.get("userId");
+        return new UserPrincipal(userId.toString());
+    }
+}

--- a/src/main/resources/static/ws-test.html
+++ b/src/main/resources/static/ws-test.html
@@ -2,7 +2,7 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8"/>
-  <title>WebSocket 자동화 테스트</title>
+  <title>WebSocket 테스트</title>
   <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
   <style>
@@ -28,21 +28,21 @@
   </style>
 </head>
 <body>
-<h2>WebSocket 자동화 테스트 클라이언트</h2>
+
+<h2>WebSocket 클라이언트 테스트</h2>
 
 <div>
+  <label>소켓 토큰 (JWT):</label>
+  <input type="text" id="socketToken" placeholder="소켓 JWT를 입력하세요" size="80"/><br/>
+
   <label>채팅방 ID:</label>
-  <input type="number" id="chatRoomId" placeholder="예: 1"/>
-  <label>예약 ID:</label>
-  <input type="number" id="reservationId" placeholder="예: 1"/>
-  <br/>
-  <label>보내는 사람(senderId):</label>
-  <input type="number" id="senderId" placeholder="예: 7"/>
+  <input type="number" id="chatRoomId" placeholder="예: 1"/><br/>
+
   <label>받는 사람(receiverId):</label>
-  <input type="number" id="receiverId" placeholder="예: 8"/>
-  <br/>
-  <label>메시지 내용:</label>
-  <input type="text" id="messageInput" placeholder="메시지를 입력하세요"/>
+  <input type="number" id="receiverId" placeholder="예: 2"/><br/>
+
+  <label>메시지:</label>
+  <input type="text" id="messageInput" placeholder="내용 입력" size="40"/>
   <button onclick="sendMessage()">전송</button>
 </div>
 
@@ -54,68 +54,68 @@
 
 <script>
   let stompClient = null;
+  let connectedUserId = null;
 
-  function connect(chatRoomId, senderId, callback) {
-    const socket = new SockJS("http://localhost:8080/ws-nest");
+  function connect(chatRoomId, token, callback) {
+    const socket = new SockJS(`http://localhost:8080/ws-nest?token=${token}`);
     stompClient = Stomp.over(socket);
 
     stompClient.connect({}, function () {
-      stompClient.subscribe(`/topic/chat_room/${chatRoomId}`, function (msg) {
+      console.log("✅ 연결 성공");
+
+      // 메시지 구독
+      stompClient.subscribe(`/queue/message`, function (msg) {
         const data = JSON.parse(msg.body);
         const li = document.createElement("li");
         li.textContent = `[${data.senderId} → ${data.receiverId}] ${data.content}`;
         document.getElementById("messageList").appendChild(li);
       });
 
-      stompClient.subscribe(`/queue/error/${senderId}`, function (msg) {
-        try {
-          const errorBody = JSON.parse(msg.body);
-          console.log("🚨 에러 메시지 수신:", errorBody);
-
-          const li = document.createElement("li");
-          li.textContent = `⚠️ [${errorBody.status}] ${errorBody.message || "에러 발생"}`;
-          document.getElementById("errorList").appendChild(li);
-        } catch (e) {
-          console.error("에러 메시지 파싱 실패:", e, msg.body);
-        }
+      // 에러 구독
+      stompClient.subscribe(`/queue/error`, function (msg) {
+        const error = JSON.parse(msg.body);
+        const li = document.createElement("li");
+        li.textContent = `⚠️ [${error.status}] ${error.message}`;
+        document.getElementById("errorList").appendChild(li);
       });
-      console.log("✅ WebSocket 연결 완료");
+
       if (callback) {
         callback();
       }
+    }, function (error) {
+      console.error("❌ 연결 실패:", error);
     });
   }
 
   function sendMessage() {
+    const token = document.getElementById("socketToken").value.trim();
     const chatRoomId = document.getElementById("chatRoomId").value;
-    const reservationId = document.getElementById("reservationId").value;
-    const senderId = document.getElementById("senderId").value;
     const receiverId = document.getElementById("receiverId").value;
     const content = document.getElementById("messageInput").value;
 
-    if (!chatRoomId || !senderId) {
-      alert("채팅방 ID와 senderId를 입력하세요!");
+    if (!token || !chatRoomId) {
+      alert("소켓 토큰과 채팅방 ID를 입력하세요.");
       return;
     }
 
-    const messagePayload = {
-      reservationId: Number(reservationId),
+    // 연결되지 않았으면 먼저 연결
+    if (!stompClient || !stompClient.connected) {
+      connect(chatRoomId, token, () => {
+        sendMessage(); // 재호출
+      });
+      return;
+    }
+
+    // 메시지 전송
+    stompClient.send(`/app/chat_room/${chatRoomId}/message`, {}, JSON.stringify({
       roomId: Number(chatRoomId),
-      senderId: Number(senderId),
       receiverId: Number(receiverId),
       content: content
-    };
-
-    if (!stompClient || !stompClient.connected) {
-      connect(chatRoomId, senderId, () => {
-        stompClient.send(`/app/chat_room/${chatRoomId}/message`, {}, JSON.stringify(messagePayload));
-      });
-    } else {
-      stompClient.send(`/app/chat_room/${chatRoomId}/message`, {}, JSON.stringify(messagePayload));
-    }
+    }));
 
     document.getElementById("messageInput").value = "";
   }
 </script>
+
 </body>
 </html>

--- a/src/main/resources/static/ws-test.html
+++ b/src/main/resources/static/ws-test.html
@@ -2,7 +2,7 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8"/>
-  <title>WebSocket 테스트</title>
+  <title>WebSocket JWT 테스트</title>
   <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
   <style>
@@ -29,24 +29,24 @@
 </head>
 <body>
 
-<h2>WebSocket 클라이언트 테스트</h2>
+<h2>💬 WebSocket JWT 클라이언트</h2>
 
 <div>
-  <label>소켓 토큰 (JWT):</label>
-  <input type="text" id="socketToken" placeholder="소켓 JWT를 입력하세요" size="80"/><br/>
+  <label>🔑 소켓 토큰 (JWT):</label><br/>
+  <input type="text" id="socketToken" placeholder="JWT를 입력하세요" size="80"/><br/>
 
-  <label>채팅방 ID:</label>
+  <label>💬 채팅방 ID:</label>
   <input type="number" id="chatRoomId" placeholder="예: 1"/><br/>
 
-  <label>받는 사람(receiverId):</label>
+  <label>📨 받는 사람 ID (receiverId):</label>
   <input type="number" id="receiverId" placeholder="예: 2"/><br/>
 
-  <label>메시지:</label>
-  <input type="text" id="messageInput" placeholder="내용 입력" size="40"/>
+  <label>✉️ 메시지:</label>
+  <input type="text" id="messageInput" placeholder="메시지를 입력하세요" size="50"/>
   <button onclick="sendMessage()">전송</button>
 </div>
 
-<h3>📨 수신 메시지</h3>
+<h3>📥 수신 메시지</h3>
 <ul id="messageList"></ul>
 
 <h3>❌ 에러 메시지</h3>
@@ -54,65 +54,61 @@
 
 <script>
   let stompClient = null;
-  let connectedUserId = null;
 
-  function connect(chatRoomId, token, callback) {
+  function connect(token, callback) {
     const socket = new SockJS(`http://localhost:8080/ws-nest?token=${token}`);
     stompClient = Stomp.over(socket);
 
-    stompClient.connect({}, function () {
-      console.log("✅ 연결 성공");
+    stompClient.connect({}, () => {
+      console.log("✅ WebSocket 연결 성공");
 
-      // 메시지 구독
-      stompClient.subscribe(`/queue/message`, function (msg) {
+      // 사용자 전용 메시지 구독
+      stompClient.subscribe("/user/queue/message", (msg) => {
         const data = JSON.parse(msg.body);
         const li = document.createElement("li");
         li.textContent = `[${data.senderId} → ${data.receiverId}] ${data.content}`;
         document.getElementById("messageList").appendChild(li);
       });
 
-      // 에러 구독
-      stompClient.subscribe(`/queue/error`, function (msg) {
+      // 사용자 전용 에러 메시지 구독
+      stompClient.subscribe("/user/queue/error", (msg) => {
         const error = JSON.parse(msg.body);
         const li = document.createElement("li");
-        li.textContent = `⚠️ [${error.status}] ${error.message}`;
+        li.textContent = `⚠️ ${error.status || ""} ${error.message}`;
         document.getElementById("errorList").appendChild(li);
       });
 
       if (callback) {
         callback();
       }
-    }, function (error) {
+    }, (error) => {
       console.error("❌ 연결 실패:", error);
     });
   }
 
   function sendMessage() {
     const token = document.getElementById("socketToken").value.trim();
-    const chatRoomId = document.getElementById("chatRoomId").value;
-    const receiverId = document.getElementById("receiverId").value;
-    const content = document.getElementById("messageInput").value;
+    const chatRoomId = document.getElementById("chatRoomId").value.trim();
+    const receiverId = document.getElementById("receiverId").value.trim();
+    const content = document.getElementById("messageInput").value.trim();
 
-    if (!token || !chatRoomId) {
-      alert("소켓 토큰과 채팅방 ID를 입력하세요.");
+    if (!token || !chatRoomId || !receiverId || !content) {
+      alert("모든 필드를 입력해주세요.");
       return;
     }
 
-    // 연결되지 않았으면 먼저 연결
     if (!stompClient || !stompClient.connected) {
-      connect(chatRoomId, token, () => {
-        sendMessage(); // 재호출
-      });
+      connect(token, () => sendMessage());
       return;
     }
 
-    // 메시지 전송
-    stompClient.send(`/app/chat_room/${chatRoomId}/message`, {}, JSON.stringify({
+    const payload = {
       roomId: Number(chatRoomId),
       receiverId: Number(receiverId),
       content: content
-    }));
+    };
 
+    stompClient.send(`/app/chat_room/${chatRoomId}/message`, {}, JSON.stringify(payload));
     document.getElementById("messageInput").value = "";
   }
 </script>


### PR DESCRIPTION
Closes #60 

---

## 🔎 작업 내용

- 메시지 처리 시 인증객체(principal)를 통해 사용자 식별이 가능하도록 수정
- 1 대 1 채팅 연결 완료

---

## 🛠️ 변경 사항

- HandshakeInterceptor 에서 jwt토큰을 추출해 userId 저장
- HandshackerHandler에서 principal 생성, 등록
- 컨트롤러에서 principal을 활용해 메시지 송신자 식별

---

## 🧩 트러블 슈팅

- principal 에 null이 저장되는 에러 발생
- 웹소켓 연결 시 userid를 세션에 저장하지 않아서 인증정보가 누락되었음
- DefaultHandshakeHandler를 구현해 인증했던 정보를 불러와 userid를 principal로 저장해 해결

---

## 🧯 해결해야 할 문제

- 전송 실패시 에러 응답 처리 
---

## 📌 참고 사항

- 송신 : /app/chat_room/{chatroomId}/message
- 수신 : /user/queue/message
- 소켓 연결 uri : ws://localhost:8080/ws-nest/websocket?token={token}

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인