### PR TITLE
[#73] Feat/oauth2 소셜로그인 구현

### DIFF
--- a/src/main/java/caffeine/nest_dev/common/config/JwtUtil.java
+++ b/src/main/java/caffeine/nest_dev/common/config/JwtUtil.java
@@ -42,6 +42,18 @@ public class JwtUtil {
         this.stringRedisTemplate = stringRedisTemplate;
     }
 
+    public String createTempAccessToken(String email) {
+        long now = System.currentTimeMillis();
+        long tempExpiration = 5 * 60 * 1000L; // 5분
+        return Jwts.builder()
+                .subject(email)
+                .claim("key", "TEMP")
+                .issuedAt(new Date(now))
+                .expiration(new Date(now + tempExpiration))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
     public String createAccessToken(User user) {
         long now = System.currentTimeMillis();
         return Jwts.builder()

--- a/src/main/java/caffeine/nest_dev/common/config/RestClientConfig.java
+++ b/src/main/java/caffeine/nest_dev/common/config/RestClientConfig.java
@@ -1,0 +1,24 @@
+package caffeine.nest_dev.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient() {
+
+        // 네트워크 안정성을 위해 시간 설정
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000); // 연결 타임아웃 5초
+        factory.setReadTimeout(10000); // 읽기 타임아웃 10초
+
+        return RestClient.builder()
+                .requestFactory(factory)
+                .build();
+    }
+
+}

--- a/src/main/java/caffeine/nest_dev/common/config/SecurityConfig.java
+++ b/src/main/java/caffeine/nest_dev/common/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/api/auth/signup", "/api/auth/login", "/api/categories", "/api/keywords", "/ws/**",
-            "/ws-nest/**"
+            "/ws-nest/**", "/oauth2/**"
             // 조회 url 추가
     };
 

--- a/src/main/java/caffeine/nest_dev/common/config/WebConfig.java
+++ b/src/main/java/caffeine/nest_dev/common/config/WebConfig.java
@@ -1,0 +1,16 @@
+package caffeine.nest_dev.common.config;
+
+import caffeine.nest_dev.oauth2.controller.converter.OAuth2ProviderConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    // PathVariable 을 enum으로 받을 수 있도록 converter 등록
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new OAuth2ProviderConverter());
+    }
+}

--- a/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
@@ -11,19 +11,17 @@ public enum ErrorCode implements BaseCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "토큰이 전달되지 않았습니다."),
     TOKEN_USER_MISMATCH(HttpStatus.UNAUTHORIZED, "토큰의 사용자 정보가 일치하지 않습니다."),
+    INVALID_STATE(HttpStatus.UNAUTHORIZED, "state가 일치하지 않습니다."),
 
     // User
-    NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "유저가 존재하지 않습니다."),
     ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "접근 가능한 사용자가 아닙니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    EXTRA_INFO_REQUIRED(HttpStatus.BAD_REQUEST, "사용자 역할과 비밀번호는 필수입니다."),
 
     // Ticket
     NOT_FOUND_TICKET(HttpStatus.NOT_FOUND, "이용권이 없습니다."),
-
-
-    // user
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "접근 가능한 사용자가 아닙니다."),
 
     // Complaint
     ERROR_CREATE_COMPLAINT(HttpStatus.CREATED, "민원이 생성되었습니다."),

--- a/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
@@ -18,7 +18,9 @@ public enum ErrorCode implements BaseCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "접근 가능한 사용자가 아닙니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    EXTRA_INFO_REQUIRED(HttpStatus.BAD_REQUEST, "사용자 역할과 비밀번호는 필수입니다."),
+    EXTRA_INFO_REQUIRED(HttpStatus.BAD_REQUEST, "사용자 역할과 비밀번호, 이름은 필수입니다."),
+    EMPTY_UPDATE_REQUEST(HttpStatus.BAD_REQUEST, "수정하려는 항목 중 하나는 필수 입력값입니다."),
+    NEW_PASSWORD_SAME_AS_CURRENT(HttpStatus.BAD_REQUEST, "새 비밀번호가 현재 비밀번호와 동일합니다."),
 
     // Ticket
     NOT_FOUND_TICKET(HttpStatus.NOT_FOUND, "이용권이 없습니다."),

--- a/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
@@ -76,6 +76,10 @@ public enum ErrorCode implements BaseCode {
     // Certificate
     NOT_FOUND_CERTIFICATE(HttpStatus.BAD_REQUEST, "경력증명서가 존재하지 않습니다."),
 
+    // OAuth2
+    INVALID_SOCIAL_TYPE(HttpStatus.BAD_REQUEST, "소셜 로그인 타입이 일치하지 않습니다."),
+
+
 
     // ChatRoom
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),

--- a/src/main/java/caffeine/nest_dev/common/enums/SuccessCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/SuccessCode.java
@@ -10,11 +10,11 @@ public enum SuccessCode implements BaseCode {
     SUCCESS_REISSUE_TOKEN(HttpStatus.OK, "토큰을 재발행합니다."),
 
     // User
-    SUCCESS_FIND_USER(HttpStatus.OK, "상세페이지 조회를 성공하였습니다."),
+    SUCCESS_FIND_USER(HttpStatus.OK, "마이페이지 조회를 성공하였습니다."),
     SUCCESS_UPDATE_USER(HttpStatus.OK, "정보 수정을 성공하였습니다."),
     SUCCESS_UPDATE_PASSWORD(HttpStatus.OK, "비밀번호 수정을 성공하였습니다."),
     SUCCESS_DELETE_USER(HttpStatus.OK, "회원 탈퇴가 완료되었습니다."),
-    SUCCESS_UPDATE_USER_ROLE(HttpStatus.OK, "회원의 역할이 수정되었습니다."),
+    SUCCESS_UPDATE_EXTRA_INFO(HttpStatus.OK, "추가 정보 입력이 완료되었습니다."),
 
     // Ticket
     SUCCESS_TICKET_CREATED(HttpStatus.CREATED, "이용권에 등록을 성공하였습니다."),

--- a/src/main/java/caffeine/nest_dev/common/enums/SuccessCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/SuccessCode.java
@@ -14,6 +14,7 @@ public enum SuccessCode implements BaseCode {
     SUCCESS_UPDATE_USER(HttpStatus.OK, "정보 수정을 성공하였습니다."),
     SUCCESS_UPDATE_PASSWORD(HttpStatus.OK, "비밀번호 수정을 성공하였습니다."),
     SUCCESS_DELETE_USER(HttpStatus.OK, "회원 탈퇴가 완료되었습니다."),
+    SUCCESS_UPDATE_USER_ROLE(HttpStatus.OK, "회원의 역할이 수정되었습니다."),
 
     // Ticket
     SUCCESS_TICKET_CREATED(HttpStatus.CREATED, "이용권에 등록을 성공하였습니다."),

--- a/src/main/java/caffeine/nest_dev/domain/auth/controller/AuthController.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/controller/AuthController.java
@@ -66,7 +66,7 @@ public class AuthController {
     }
 
     // 토큰 재발급
-    @PostMapping("/refresh")
+    @PostMapping("/token/refresh")
     public ResponseEntity<CommonResponse<TokenResponseDto>> reissue(
             @RequestBody RefreshTokenRequestDto dto,
             @AuthenticationPrincipal UserDetailsImpl userDetails

--- a/src/main/java/caffeine/nest_dev/domain/auth/dto/request/AuthRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/dto/request/AuthRequestDto.java
@@ -1,7 +1,5 @@
 package caffeine.nest_dev.domain.auth.dto.request;
 
-import caffeine.nest_dev.domain.user.entity.User;
-import caffeine.nest_dev.domain.user.enums.UserGrade;
 import caffeine.nest_dev.domain.user.enums.UserRole;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -37,16 +35,16 @@ public class AuthRequestDto {
     @NotNull(message = "역할 입력은 필수입니다.")
     private UserRole userRole;
 
-    public User toEntity(String encodedPassword) {
-        return User.builder()
-                .name(name)
-                .email(email)
-                .nickName(nickName)
-                .password(encodedPassword)
-                .phoneNumber(phoneNumber)
-                .userRole(userRole)
-                .userGrade(UserGrade.SEED)
-                .totalPrice(0)
-                .build();
-    }
+//    public User toEntity(String encodedPassword) {
+//        return User.builder()
+//                .name(name)
+//                .email(email)
+//                .nickName(nickName)
+//                .password(encodedPassword)
+//                .phoneNumber(phoneNumber)
+//                .userRole(userRole)
+//                .userGrade(UserGrade.SEED)
+//                .totalPrice(0)
+//                .build();
+//    }
 }

--- a/src/main/java/caffeine/nest_dev/domain/auth/dto/request/AuthRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/dto/request/AuthRequestDto.java
@@ -34,7 +34,7 @@ public class AuthRequestDto {
     @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
     private String phoneNumber;
 
-    @NotNull(message = "회원 구분은 필수입니다.")
+    @NotNull(message = "역할 입력은 필수입니다.")
     private UserRole userRole;
 
     public User toEntity(String encodedPassword) {
@@ -44,8 +44,9 @@ public class AuthRequestDto {
                 .nickName(nickname)
                 .password(encodedPassword)
                 .phoneNumber(phoneNumber)
-                .userGrade(UserGrade.SEED)
                 .userRole(userRole)
+                .userGrade(UserGrade.SEED)
+                .totalPrice(0)
                 .build();
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/auth/dto/request/AuthRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/dto/request/AuthRequestDto.java
@@ -24,7 +24,7 @@ public class AuthRequestDto {
     private String email;
 
     @NotBlank(message = "닉네임은 필수입니다.")
-    private String nickname;
+    private String nickName;
 
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*[0-9])(?=.*\\W).{8,}$", message = "비밀번호 형식이 올바르지 않습니다.")
@@ -41,7 +41,7 @@ public class AuthRequestDto {
         return User.builder()
                 .name(name)
                 .email(email)
-                .nickName(nickname)
+                .nickName(nickName)
                 .password(encodedPassword)
                 .phoneNumber(phoneNumber)
                 .userRole(userRole)

--- a/src/main/java/caffeine/nest_dev/domain/auth/dto/request/DeleteRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/dto/request/DeleteRequestDto.java
@@ -1,0 +1,15 @@
+package caffeine.nest_dev.domain.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeleteRequestDto {
+
+    private String password;
+    private String refreshToken;
+
+}

--- a/src/main/java/caffeine/nest_dev/domain/auth/dto/response/AuthResponseDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/dto/response/AuthResponseDto.java
@@ -3,6 +3,7 @@ package caffeine.nest_dev.domain.auth.dto.response;
 import caffeine.nest_dev.domain.user.entity.User;
 import caffeine.nest_dev.domain.user.enums.UserGrade;
 import caffeine.nest_dev.domain.user.enums.UserRole;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,7 @@ public class AuthResponseDto {
     private String phoneNumber;
     private UserGrade userGrade;
     private UserRole userRole;
+    private LocalDateTime createdAt;
 
     public static AuthResponseDto of(User user) {
         return AuthResponseDto.builder()
@@ -29,6 +31,7 @@ public class AuthResponseDto {
                 .phoneNumber(user.getPhoneNumber())
                 .userGrade(user.getUserGrade())
                 .userRole(user.getUserRole())
+                .createdAt(user.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/auth/repository/TokenRepository.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/repository/TokenRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class RefreshTokenRepository {
+public class TokenRepository {
 
     private final StringRedisTemplate stringRedisTemplate;
 

--- a/src/main/java/caffeine/nest_dev/domain/auth/service/AuthService.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/service/AuthService.java
@@ -10,10 +10,13 @@ import caffeine.nest_dev.domain.auth.dto.request.RefreshTokenRequestDto;
 import caffeine.nest_dev.domain.auth.dto.response.AuthResponseDto;
 import caffeine.nest_dev.domain.auth.dto.response.LoginResponseDto;
 import caffeine.nest_dev.domain.auth.dto.response.TokenResponseDto;
-import caffeine.nest_dev.domain.auth.repository.RefreshTokenRepository;
+import caffeine.nest_dev.domain.auth.repository.TokenRepository;
 import caffeine.nest_dev.domain.user.entity.User;
+import caffeine.nest_dev.domain.user.enums.SocialType;
 import caffeine.nest_dev.domain.user.repository.UserRepository;
 import caffeine.nest_dev.domain.user.service.UserService;
+import caffeine.nest_dev.oauth2.userinfo.OAuth2UserInfo;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,7 +31,7 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final UserService userService;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenRepository tokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final StringRedisTemplate stringRedisTemplate;
@@ -58,11 +61,16 @@ public class AuthService {
     public LoginResponseDto login(LoginRequestDto dto) {
         // 유저 조회
         User user = userRepository.findByEmailAndIsDeletedFalse(dto.getEmail())
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER));
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
 
         // 비밀번호 일치 여부 검증
         if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
             throw new BaseException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        // Local 로그인 으로 변경
+        if (user.getSocialType() != SocialType.LOCAL) {
+            user.updateSocialType(SocialType.LOCAL, null);
         }
 
         // 토큰 생성
@@ -70,7 +78,7 @@ public class AuthService {
         String refreshToken = jwtUtil.createRefreshToken(user);
 
         // redis에 저장
-        refreshTokenRepository.save(user.getId(), refreshToken, refreshTokenExpiration);
+        tokenRepository.save(user.getId(), refreshToken, refreshTokenExpiration);
 
         return LoginResponseDto.of(user, accessToken, refreshToken);
     }
@@ -100,7 +108,7 @@ public class AuthService {
         }
 
         // refreshToken 일치 여부 검증
-        String refreshTokenByUserId = refreshTokenRepository.findByUserId(userIdFromRefreshToken);
+        String refreshTokenByUserId = tokenRepository.findByUserId(userIdFromRefreshToken);
         if (!refreshToken.equals(refreshTokenByUserId)) {
             throw new BaseException(ErrorCode.INVALID_TOKEN);
         }
@@ -120,7 +128,7 @@ public class AuthService {
         String refreshToken = dto.getRefreshToken();
 
         // refreshToken 일치 여부 검증
-        String refreshTokenByUserId = refreshTokenRepository.findByUserId(userId);
+        String refreshTokenByUserId = tokenRepository.findByUserId(userId);
         if (!refreshToken.equals(refreshTokenByUserId)) {
             throw new BaseException(ErrorCode.INVALID_TOKEN);
         }
@@ -141,7 +149,25 @@ public class AuthService {
         User user = userService.findByIdAndIsDeletedFalseOrElseThrow(userIdFromToken);
         String newAccessToken = jwtUtil.createAccessToken(user);
 
-
         return TokenResponseDto.of(newAccessToken);
+    }
+
+    // DB에서 유저 조회
+    @Transactional
+    public User findUserByEmail(OAuth2UserInfo userInfo, SocialType provider) {
+        return userRepository.findByEmailAndIsDeletedFalse(userInfo.getEmail())
+                .orElseGet(() -> registerIfAbsent(userInfo, provider));
+    }
+
+    @Transactional
+    // OAuth2UserInfo 정보로 user 객체 만들기
+    public User registerIfAbsent(OAuth2UserInfo userInfo, SocialType provider) {
+        return userRepository.save(User.builder()
+                .email(userInfo.getEmail())
+                .nickName(userInfo.getNickName())
+                .password(passwordEncoder.encode(UUID.randomUUID().toString())) // 임의의 비밀번호 사용
+                .socialType(provider)
+                .socialId(userInfo.getId())
+                .build());
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/career/dto/request/CareerRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/career/dto/request/CareerRequestDto.java
@@ -1,7 +1,6 @@
 package caffeine.nest_dev.domain.career.dto.request;
 
 import caffeine.nest_dev.domain.career.entity.Career;
-import caffeine.nest_dev.domain.career.enums.CareerStatus;
 import caffeine.nest_dev.domain.profile.entity.Profile;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
@@ -11,8 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CareerRequestDto {
 
     @NotBlank(message = "회사명은 필수입니다.")
@@ -25,13 +24,12 @@ public class CareerRequestDto {
 
     private List<String> certificates;
 
-    public Career toEntity(CareerRequestDto dto, Profile profile) {
+    public static Career toEntity(CareerRequestDto dto, Profile profile) {
         return Career.builder()
-                .company(dto.company)
+                .company(dto.getCompany())
                 .profile(profile)
-                .startAt(dto.startAt)
-                .endAt(dto.endAt)
-                .careerStatus(CareerStatus.UNAUTHORIZED)
+                .startAt(dto.getStartAt())
+                .endAt(dto.getEndAt())
                 .build();
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/career/dto/request/UpdateCareerRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/career/dto/request/UpdateCareerRequestDto.java
@@ -1,7 +1,6 @@
 package caffeine.nest_dev.domain.career.dto.request;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,5 +13,4 @@ public class UpdateCareerRequestDto {
     private String company;
     private LocalDateTime startAt;
     private LocalDateTime endAt;
-    private List<String> certificate;
 }

--- a/src/main/java/caffeine/nest_dev/domain/career/dto/response/CareerResponseDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/career/dto/response/CareerResponseDto.java
@@ -19,6 +19,7 @@ public class CareerResponseDto {
     private LocalDateTime endAt;
     private CareerStatus careerStatus;
     private List<CertificateResponseDto> certificates;
+    private LocalDateTime createdAt;
 
     public static CareerResponseDto of(Career career, List<CertificateResponseDto> list) {
         return CareerResponseDto.builder()
@@ -28,6 +29,7 @@ public class CareerResponseDto {
                 .endAt(career.getEndAt())
                 .careerStatus(career.getCareerStatus())
                 .certificates(list)
+                .createdAt(career.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/career/dto/response/FindCareerResponseDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/career/dto/response/FindCareerResponseDto.java
@@ -20,6 +20,8 @@ public class FindCareerResponseDto {
     private LocalDateTime endAt;
     private CareerStatus careerStatus;
     private List<Certificate> certificates;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     public static FindCareerResponseDto of(Career career) {
         return FindCareerResponseDto.builder()
@@ -29,6 +31,8 @@ public class FindCareerResponseDto {
                 .endAt(career.getEndAt())
                 .careerStatus(career.getCareerStatus())
                 .certificates(career.getCertificates())
+                .createdAt(career.getCreatedAt())
+                .updatedAt(career.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/caffeine/nest_dev/domain/career/entity/Career.java
+++ b/src/main/java/caffeine/nest_dev/domain/career/entity/Career.java
@@ -22,18 +22,16 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
 @Getter
 @Entity
 @Table(name = "careers")
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Career extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -57,6 +55,15 @@ public class Career extends BaseEntity {
     @OneToMany(mappedBy = "career", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Certificate> certificates = new ArrayList<>();
 
+    @Builder
+    public Career(Profile profile, String company, LocalDateTime startAt, LocalDateTime endAt) {
+        this.profile = profile;
+        this.company = company;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.careerStatus = CareerStatus.UNAUTHORIZED;
+    }
+
     public void updateCareerStatus(CareerStatus newStatus) {
         this.careerStatus = newStatus;
     }
@@ -70,8 +77,11 @@ public class Career extends BaseEntity {
             this.startAt = dto.getStartAt();
         }
 
-        if (dto.getStartAt() != null) {
-            this.endAt = dto.getEndAt();
-        }
+        this.endAt = dto.getEndAt();
+    }
+
+    public void addCertificate(Certificate certificate) {
+        this.certificates.add(certificate);
+        certificate.updateCareer(this);
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/career/service/CareerService.java
+++ b/src/main/java/caffeine/nest_dev/domain/career/service/CareerService.java
@@ -45,7 +45,7 @@ public class CareerService {
 
         // 프로필 조회
         Profile profile = profileRepository.findById(profileId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER));
+                .orElseThrow(() -> new BaseException(ErrorCode.PROFILE_NOT_FOUND));
 
         // 경력 Entity 생성 및 profile 과 연관관계 설정
         Career career = dto.toEntity(dto, profile);

--- a/src/main/java/caffeine/nest_dev/domain/certificate/entity/Certificate.java
+++ b/src/main/java/caffeine/nest_dev/domain/certificate/entity/Certificate.java
@@ -36,4 +36,8 @@ public class Certificate {
     public void updateCertificate(UpdateCertificateRequestDto dto) {
         this.fileUrl = dto.getFileUrl();
     }
+
+    public void updateCareer(Career career) {
+        this.career = career;
+    }
 }

--- a/src/main/java/caffeine/nest_dev/domain/profile/service/ProfileService.java
+++ b/src/main/java/caffeine/nest_dev/domain/profile/service/ProfileService.java
@@ -13,15 +13,12 @@ import caffeine.nest_dev.domain.profile.dto.response.ProfileResponseDto;
 import caffeine.nest_dev.domain.profile.entity.Profile;
 import caffeine.nest_dev.domain.profile.repository.ProfileRepository;
 import caffeine.nest_dev.domain.user.entity.User;
-import caffeine.nest_dev.domain.user.repository.UserRepository;
 import caffeine.nest_dev.domain.user.service.UserService;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -29,7 +26,6 @@ import org.springframework.stereotype.Service;
 public class ProfileService {
 
     private final ProfileRepository profileRepository;
-    private final UserRepository userRepository;
     private final UserService userService;
     private final CategoryRepository categoryRepository;
     private final KeywordRepository keywordRepository;

--- a/src/main/java/caffeine/nest_dev/domain/user/controller/UserController.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/controller/UserController.java
@@ -2,7 +2,7 @@ package caffeine.nest_dev.domain.user.controller;
 
 import caffeine.nest_dev.common.dto.CommonResponse;
 import caffeine.nest_dev.common.enums.SuccessCode;
-import caffeine.nest_dev.domain.auth.dto.request.RefreshTokenRequestDto;
+import caffeine.nest_dev.domain.auth.dto.request.DeleteRequestDto;
 import caffeine.nest_dev.domain.user.dto.request.ExtraInfoRequestDto;
 import caffeine.nest_dev.domain.user.dto.request.UpdatePasswordRequestDto;
 import caffeine.nest_dev.domain.user.dto.request.UserRequestDto;
@@ -71,13 +71,13 @@ public class UserController {
     @PatchMapping("/extraInfo")
     public ResponseEntity<CommonResponse<Void>> extraInfo(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestBody ExtraInfoRequestDto dto
+            @Valid @RequestBody ExtraInfoRequestDto dto
     ) {
 
         userService.updateExtraInfo(userDetails.getId(), dto);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(CommonResponse.of(SuccessCode.SUCCESS_UPDATE_USER_ROLE));
+                .body(CommonResponse.of(SuccessCode.SUCCESS_UPDATE_EXTRA_INFO));
     }
 
     // 회원 탈퇴
@@ -85,10 +85,10 @@ public class UserController {
     public ResponseEntity<CommonResponse<Void>> deleteUser(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestHeader("Authorization") String accessToken,
-            @RequestBody RefreshTokenRequestDto dto
+            @RequestBody DeleteRequestDto dto
     ) {
 
-        userService.deleteUser(userDetails.getId(), accessToken, dto.getRefreshToken());
+        userService.deleteUser(userDetails.getId(), accessToken, dto);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_DELETE_USER));

--- a/src/main/java/caffeine/nest_dev/domain/user/controller/UserController.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package caffeine.nest_dev.domain.user.controller;
 import caffeine.nest_dev.common.dto.CommonResponse;
 import caffeine.nest_dev.common.enums.SuccessCode;
 import caffeine.nest_dev.domain.auth.dto.request.RefreshTokenRequestDto;
+import caffeine.nest_dev.domain.user.dto.request.ExtraInfoRequestDto;
 import caffeine.nest_dev.domain.user.dto.request.UpdatePasswordRequestDto;
 import caffeine.nest_dev.domain.user.dto.request.UserRequestDto;
 import caffeine.nest_dev.domain.user.dto.response.UserResponseDto;
@@ -10,6 +11,7 @@ import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
 import caffeine.nest_dev.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -35,7 +37,8 @@ public class UserController {
 
         UserResponseDto dto = userService.findUser(userDetails.getId());
 
-        return ResponseEntity.ok().body(CommonResponse.of(SuccessCode.SUCCESS_FIND_USER, dto));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of(SuccessCode.SUCCESS_FIND_USER, dto));
     }
 
     // 정보 수정
@@ -47,7 +50,8 @@ public class UserController {
 
         userService.updateUser(userDetails.getId(), dto);
 
-        return ResponseEntity.ok().body(CommonResponse.of(SuccessCode.SUCCESS_UPDATE_USER));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of(SuccessCode.SUCCESS_UPDATE_USER));
     }
 
     // 비밀번호 수정
@@ -59,7 +63,21 @@ public class UserController {
 
         userService.updatePassword(userDetails.getId(), dto);
 
-        return ResponseEntity.ok().body(CommonResponse.of(SuccessCode.SUCCESS_UPDATE_PASSWORD));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of(SuccessCode.SUCCESS_UPDATE_PASSWORD));
+    }
+
+    // MENTEE or MENTOR 선택 / 전화번호 입력 (추가정보)
+    @PatchMapping("/extraInfo")
+    public ResponseEntity<CommonResponse<Void>> extraInfo(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody ExtraInfoRequestDto dto
+    ) {
+
+        userService.updateExtraInfo(userDetails.getId(), dto);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of(SuccessCode.SUCCESS_UPDATE_USER_ROLE));
     }
 
     // 회원 탈퇴
@@ -72,6 +90,7 @@ public class UserController {
 
         userService.deleteUser(userDetails.getId(), accessToken, dto.getRefreshToken());
 
-        return ResponseEntity.ok().body(CommonResponse.of(SuccessCode.SUCCESS_DELETE_USER));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of(SuccessCode.SUCCESS_DELETE_USER));
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/user/dto/request/ExtraInfoRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/dto/request/ExtraInfoRequestDto.java
@@ -1,0 +1,15 @@
+package caffeine.nest_dev.domain.user.dto.request;
+
+import caffeine.nest_dev.domain.user.enums.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ExtraInfoRequestDto {
+
+    private String name;
+    private String phoneNumber;
+    private UserRole userRole;
+
+}

--- a/src/main/java/caffeine/nest_dev/domain/user/dto/request/ExtraInfoRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/dto/request/ExtraInfoRequestDto.java
@@ -1,6 +1,9 @@
 package caffeine.nest_dev.domain.user.dto.request;
 
 import caffeine.nest_dev.domain.user.enums.UserRole;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,8 +11,14 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ExtraInfoRequestDto {
 
+    @NotBlank(message = "이름은 필수 입니다.")
     private String name;
+
+    @NotBlank(message = "전화번호는 필수입니다.")
+    @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
     private String phoneNumber;
+
+    @NotNull(message = "역할 입력은 필수입니다.")
     private UserRole userRole;
 
 }

--- a/src/main/java/caffeine/nest_dev/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/dto/response/UserResponseDto.java
@@ -43,8 +43,6 @@ public class UserResponseDto {
                     .userGrade(user.getUserGrade())
                     .socialType(SocialType.LOCAL)
                     .totalPrice(user.getTotalPrice())
-                    .bank(user.getBank())
-                    .accountNumber(user.getAccountNumber())
                     .createdAt(user.getCreatedAt())
                     .updatedAt(user.getUpdatedAt())
                     .build();
@@ -61,6 +59,8 @@ public class UserResponseDto {
                 .socialType(SocialType.LOCAL)
                 .bank(user.getBank())
                 .accountNumber(user.getAccountNumber())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/dto/response/UserResponseDto.java
@@ -1,8 +1,10 @@
 package caffeine.nest_dev.domain.user.dto.response;
 
 import caffeine.nest_dev.domain.user.entity.User;
+import caffeine.nest_dev.domain.user.enums.SocialType;
 import caffeine.nest_dev.domain.user.enums.UserGrade;
 import caffeine.nest_dev.domain.user.enums.UserRole;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +12,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 값은 JSON 에 포함 X
 public class UserResponseDto {
 
     private Long id;
@@ -19,10 +22,30 @@ public class UserResponseDto {
     private String phoneNumber;
     private UserRole userRole;
     private UserGrade userGrade;
+    private SocialType socialType;
+    private Integer totalPrice;
     private String bank;
     private String accountNumber;
 
     public static UserResponseDto of(User user) {
+        if (user.getUserRole() == UserRole.MENTEE) {
+
+            return UserResponseDto.builder()
+                    .id(user.getId())
+                    .name(user.getName())
+                    .email(user.getEmail())
+                    .nickName(user.getNickName())
+                    .phoneNumber(user.getPhoneNumber())
+                    .userRole(user.getUserRole())
+                    .userGrade(user.getUserGrade())
+                    .socialType(SocialType.LOCAL)
+                    .totalPrice(user.getTotalPrice())
+                    .bank(user.getBank())
+                    .accountNumber(user.getAccountNumber())
+                    .build();
+        }
+
+        // MENTOR 일 때
         return UserResponseDto.builder()
                 .id(user.getId())
                 .name(user.getName())
@@ -30,7 +53,7 @@ public class UserResponseDto {
                 .nickName(user.getNickName())
                 .phoneNumber(user.getPhoneNumber())
                 .userRole(user.getUserRole())
-                .userGrade(user.getUserGrade())
+                .socialType(SocialType.LOCAL)
                 .bank(user.getBank())
                 .accountNumber(user.getAccountNumber())
                 .build();

--- a/src/main/java/caffeine/nest_dev/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/dto/response/UserResponseDto.java
@@ -5,6 +5,7 @@ import caffeine.nest_dev.domain.user.enums.SocialType;
 import caffeine.nest_dev.domain.user.enums.UserGrade;
 import caffeine.nest_dev.domain.user.enums.UserRole;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,6 +27,8 @@ public class UserResponseDto {
     private Integer totalPrice;
     private String bank;
     private String accountNumber;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     public static UserResponseDto of(User user) {
         if (user.getUserRole() == UserRole.MENTEE) {
@@ -42,6 +45,8 @@ public class UserResponseDto {
                     .totalPrice(user.getTotalPrice())
                     .bank(user.getBank())
                     .accountNumber(user.getAccountNumber())
+                    .createdAt(user.getCreatedAt())
+                    .updatedAt(user.getUpdatedAt())
                     .build();
         }
 

--- a/src/main/java/caffeine/nest_dev/domain/user/entity/User.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package caffeine.nest_dev.domain.user.entity;
 
 import caffeine.nest_dev.common.entity.BaseEntity;
+import caffeine.nest_dev.domain.user.dto.request.ExtraInfoRequestDto;
 import caffeine.nest_dev.domain.user.dto.request.UserRequestDto;
 import caffeine.nest_dev.domain.user.enums.SocialType;
 import caffeine.nest_dev.domain.user.enums.UserGrade;
@@ -30,7 +31,6 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private String name;
 
     private String email;
@@ -41,7 +41,6 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
     private String phoneNumber;
 
     @Enumerated(EnumType.STRING)
@@ -54,6 +53,8 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
+
+    private Integer totalPrice;
 
     private String bank;
 
@@ -95,5 +96,24 @@ public class User extends BaseEntity {
 
     public void deleteUser(boolean isDeleted) {
         this.isDeleted = isDeleted;
+    }
+
+    public void updateUserGrade(UserGrade userGrade) {
+        this.userGrade = userGrade;
+    }
+
+    public void updateExtraInfo(ExtraInfoRequestDto dto) {
+        this.name = dto.getName();
+        this.userRole = dto.getUserRole();
+        this.phoneNumber = dto.getPhoneNumber();
+    }
+
+    public void updateSocialType(SocialType socialType, String socialId) {
+        this.socialType = socialType;
+        this.socialId = socialId;
+    }
+
+    public void updateTotalPrice(Integer totalPrice) {
+        this.totalPrice = totalPrice;
     }
 }

--- a/src/main/java/caffeine/nest_dev/oauth2/client/OAuth2Client.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/client/OAuth2Client.java
@@ -1,0 +1,15 @@
+package caffeine.nest_dev.oauth2.client;
+
+import caffeine.nest_dev.domain.user.enums.SocialType;
+import caffeine.nest_dev.oauth2.userinfo.OAuth2UserInfo;
+
+public interface OAuth2Client {
+
+    SocialType getProvider();
+
+    String getAccessToken(String authorizationCode);
+
+    String generateLoginPageUrl();
+
+    OAuth2UserInfo retrieveUserInfo(String accessToken);
+}

--- a/src/main/java/caffeine/nest_dev/oauth2/client/OAuth2ClientService.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/client/OAuth2ClientService.java
@@ -1,0 +1,50 @@
+package caffeine.nest_dev.oauth2.client;
+
+import caffeine.nest_dev.common.enums.ErrorCode;
+import caffeine.nest_dev.common.exception.BaseException;
+import caffeine.nest_dev.domain.user.enums.SocialType;
+import caffeine.nest_dev.oauth2.userinfo.OAuth2UserInfo;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuth2ClientService {
+
+    private final Map<SocialType, OAuth2Client> oAuth2Clients;
+
+    public OAuth2ClientService(List<OAuth2Client> oAuth2Clients) {
+        this.oAuth2Clients = oAuth2Clients.stream().collect(Collectors.toMap(
+                OAuth2Client::getProvider, Function.identity()));
+    }
+
+    // SocialType에 해당하는 로그인페이지 URL 불러오기
+    public String generateLoginPageUrl(SocialType provider) {
+
+        // SocialType에 해당하는 OAuth2Client 객체 만들기
+        OAuth2Client oAuth2Client = this.create(provider);
+
+        return oAuth2Client.generateLoginPageUrl();
+    }
+
+    // SocialType 과 code 로 유저의 정보 가져오기
+    public OAuth2UserInfo getUserInfo(SocialType provider, String authorizationCode) {
+
+        OAuth2Client oAuth2Client = this.create(provider);
+
+        // code 로 accessToken 가져오기(provider 가 제공하는 토큰)
+        String accessToken = oAuth2Client.getAccessToken(authorizationCode);
+
+        // 토큰으로 소셜 제공자의 사용자 정보 가져오기
+        return oAuth2Client.retrieveUserInfo(accessToken);
+    }
+
+    // SocialType으로 OAuth2Client 객체 만들기
+    private OAuth2Client create(SocialType provider) {
+        return Optional.ofNullable(oAuth2Clients.get(provider)).orElseThrow(() -> new BaseException(
+                ErrorCode.INVALID_SOCIAL_TYPE));
+    }
+}

--- a/src/main/java/caffeine/nest_dev/oauth2/controller/OAuth2LoginController.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/controller/OAuth2LoginController.java
@@ -1,0 +1,51 @@
+package caffeine.nest_dev.oauth2.controller;
+
+
+import caffeine.nest_dev.common.dto.CommonResponse;
+import caffeine.nest_dev.common.enums.SuccessCode;
+import caffeine.nest_dev.domain.user.enums.SocialType;
+import caffeine.nest_dev.oauth2.dto.response.OAuth2LoginResponseDto;
+import caffeine.nest_dev.oauth2.service.OAuth2LoginService;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OAuth2LoginController {
+
+    private final OAuth2LoginService oAuth2LoginService;
+
+    // 로그인 페이지 요청
+    @GetMapping("/oauth2/login/{provider}")
+    public void redirectLoginPage(
+            @PathVariable SocialType provider,
+            HttpServletResponse response
+    ) throws IOException {
+
+        // socialType에 해당하는 로그인 페이지 URL 반환
+        String loginPageUrl = oAuth2LoginService.generateLoginPageUrl(provider);
+
+        // 로그인 페이지로 이동
+        response.sendRedirect(loginPageUrl);
+    }
+
+    // 소셜 로그인
+    @GetMapping("/oauth2/callback/{provider}")
+    public ResponseEntity<CommonResponse<OAuth2LoginResponseDto>> oauth2Login(
+            @PathVariable SocialType provider,
+            @RequestParam("code") String authorizationCode
+    ) {
+
+        OAuth2LoginResponseDto responseDto = oAuth2LoginService.login(provider, authorizationCode);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of(SuccessCode.SUCCESS_USER_LOGIN, responseDto));
+    }
+}

--- a/src/main/java/caffeine/nest_dev/oauth2/controller/OAuth2LoginController.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/controller/OAuth2LoginController.java
@@ -40,10 +40,12 @@ public class OAuth2LoginController {
     @GetMapping("/oauth2/callback/{provider}")
     public ResponseEntity<CommonResponse<OAuth2LoginResponseDto>> oauth2Login(
             @PathVariable SocialType provider,
-            @RequestParam("code") String authorizationCode
+            @RequestParam("code") String authorizationCode,
+            @RequestParam("state") String state
     ) {
 
-        OAuth2LoginResponseDto responseDto = oAuth2LoginService.login(provider, authorizationCode);
+        OAuth2LoginResponseDto responseDto = oAuth2LoginService.login(provider, authorizationCode,
+                state);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_USER_LOGIN, responseDto));

--- a/src/main/java/caffeine/nest_dev/oauth2/controller/converter/OAuth2ProviderConverter.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/controller/converter/OAuth2ProviderConverter.java
@@ -1,0 +1,18 @@
+package caffeine.nest_dev.oauth2.controller.converter;
+
+import caffeine.nest_dev.common.enums.ErrorCode;
+import caffeine.nest_dev.common.exception.BaseException;
+import caffeine.nest_dev.domain.user.enums.SocialType;
+import org.springframework.core.convert.converter.Converter;
+
+public class OAuth2ProviderConverter implements Converter<String, SocialType> {
+
+    @Override
+    public SocialType convert(String source) {
+        try {
+            return SocialType.valueOf(source.toUpperCase());
+        } catch (Exception e) {
+            throw new BaseException(ErrorCode.INVALID_SOCIAL_TYPE);
+        }
+    }
+}

--- a/src/main/java/caffeine/nest_dev/oauth2/dto/response/OAuth2LoginResponseDto.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/dto/response/OAuth2LoginResponseDto.java
@@ -1,0 +1,28 @@
+package caffeine.nest_dev.oauth2.dto.response;
+
+import caffeine.nest_dev.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class OAuth2LoginResponseDto {
+
+    private Long id;
+    private String name;
+    private String email;
+    private String accessToken;
+    private String refreshToken;
+
+    public static OAuth2LoginResponseDto of(User user, String accessToken, String refreshToken) {
+        return OAuth2LoginResponseDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/caffeine/nest_dev/oauth2/dto/response/OAuth2LoginResponseDto.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/dto/response/OAuth2LoginResponseDto.java
@@ -11,16 +11,18 @@ import lombok.Getter;
 public class OAuth2LoginResponseDto {
 
     private Long id;
-    private String name;
     private String email;
+    private String nickName;
+    private boolean isNew;
     private String accessToken;
     private String refreshToken;
 
-    public static OAuth2LoginResponseDto of(User user, String accessToken, String refreshToken) {
+    public static OAuth2LoginResponseDto of(User user, String accessToken, String refreshToken, boolean isNew) {
         return OAuth2LoginResponseDto.builder()
                 .id(user.getId())
-                .name(user.getName())
                 .email(user.getEmail())
+                .nickName(user.getNickName())
+                .isNew(isNew)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();

--- a/src/main/java/caffeine/nest_dev/oauth2/service/OAuth2LoginService.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/service/OAuth2LoginService.java
@@ -1,31 +1,29 @@
 package caffeine.nest_dev.oauth2.service;
 
 import caffeine.nest_dev.common.config.JwtUtil;
-import caffeine.nest_dev.common.config.PasswordEncoder;
-import caffeine.nest_dev.domain.auth.repository.RefreshTokenRepository;
+import caffeine.nest_dev.common.enums.ErrorCode;
+import caffeine.nest_dev.common.exception.BaseException;
+import caffeine.nest_dev.domain.auth.repository.TokenRepository;
+import caffeine.nest_dev.domain.auth.service.AuthService;
 import caffeine.nest_dev.domain.user.entity.User;
 import caffeine.nest_dev.domain.user.enums.SocialType;
-import caffeine.nest_dev.domain.user.enums.UserGrade;
-import caffeine.nest_dev.domain.user.enums.UserRole;
-import caffeine.nest_dev.domain.user.repository.UserRepository;
 import caffeine.nest_dev.oauth2.client.OAuth2ClientService;
 import caffeine.nest_dev.oauth2.dto.response.OAuth2LoginResponseDto;
 import caffeine.nest_dev.oauth2.userinfo.OAuth2UserInfo;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class OAuth2LoginService {
 
-    private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final OAuth2ClientService oAuth2ClientService;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenRepository tokenRepository;
+    private final AuthService authService;
+    private final StringRedisTemplate stringRedisTemplate;
 
     @Value("${jwt.refresh-token-expiration}")
     private long refreshTokenExpiration;
@@ -34,15 +32,33 @@ public class OAuth2LoginService {
         return oAuth2ClientService.generateLoginPageUrl(provider);
     }
 
-    @Transactional
-    public OAuth2LoginResponseDto login(SocialType provider, String authorizationCode) {
+    public OAuth2LoginResponseDto login(SocialType provider, String authorizationCode,
+            String state) {
+
+        // state 값 유효성 검증
+        String storedState = stringRedisTemplate.opsForValue().get("oauth2:state" + state);
+        if (storedState == null) {
+            throw new BaseException(ErrorCode.INVALID_STATE);
+        }
+
+        // 검증 후 redis에서 삭제
+        stringRedisTemplate.delete("oauth2:state" + state);
 
         // 소셜 제공자로부터 사용자 정보 조회
         OAuth2UserInfo userInfo = oAuth2ClientService.getUserInfo(provider, authorizationCode);
 
         // DB에서 사용자 조회 (없으면 등록)
-        User user = userRepository.findByEmailAndIsDeletedFalse(userInfo.getEmail())
-                .orElseGet(() -> registerIfAbsent(userInfo, provider));
+        User user = authService.findUserByEmail(userInfo, provider);
+
+        // 검증 후 null 값일때 반환 (신규 유저)
+        if (user.getUserRole() == null || user.getPhoneNumber() == null || user.getName() == null) {
+            // 임시 토큰 발급
+            String tempAccessToken = jwtUtil.createTempAccessToken(user.getEmail());
+            return OAuth2LoginResponseDto.of(user, tempAccessToken, null, true);
+        }
+
+        // socialType 변경
+        user.updateSocialType(provider, userInfo.getId());
 
         // accessToken 발급
         String accessToken = jwtUtil.createAccessToken(user);
@@ -50,23 +66,8 @@ public class OAuth2LoginService {
         String refreshToken = jwtUtil.createRefreshToken(user);
 
         // redis 에 refreshToken 저장
-        refreshTokenRepository.save(user.getId(), refreshToken, refreshTokenExpiration);
+        tokenRepository.save(user.getId(), refreshToken, refreshTokenExpiration);
 
-
-        return OAuth2LoginResponseDto.of(user, accessToken, refreshToken);
-    }
-
-    // OAuth2UserInfo 정보로 user 객체 만들기
-    private User registerIfAbsent(OAuth2UserInfo userInfo, SocialType provider) {
-        return userRepository.save(User.builder()
-                .name(userInfo.getName())
-                .email(userInfo.getEmail())
-                .phoneNumber(userInfo.getPhoneNumber())
-                .password(passwordEncoder.encode(UUID.randomUUID().toString())) // 임의의 비밀번호 사용
-                .socialType(provider)
-                .socialId(userInfo.getId())
-                .userRole(UserRole.MENTEE)
-                .userGrade(UserGrade.SEED)
-                .build());
+        return OAuth2LoginResponseDto.of(user, accessToken, refreshToken, false);
     }
 }

--- a/src/main/java/caffeine/nest_dev/oauth2/service/OAuth2LoginService.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/service/OAuth2LoginService.java
@@ -1,0 +1,72 @@
+package caffeine.nest_dev.oauth2.service;
+
+import caffeine.nest_dev.common.config.JwtUtil;
+import caffeine.nest_dev.common.config.PasswordEncoder;
+import caffeine.nest_dev.domain.auth.repository.RefreshTokenRepository;
+import caffeine.nest_dev.domain.user.entity.User;
+import caffeine.nest_dev.domain.user.enums.SocialType;
+import caffeine.nest_dev.domain.user.enums.UserGrade;
+import caffeine.nest_dev.domain.user.enums.UserRole;
+import caffeine.nest_dev.domain.user.repository.UserRepository;
+import caffeine.nest_dev.oauth2.client.OAuth2ClientService;
+import caffeine.nest_dev.oauth2.dto.response.OAuth2LoginResponseDto;
+import caffeine.nest_dev.oauth2.userinfo.OAuth2UserInfo;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2LoginService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+    private final OAuth2ClientService oAuth2ClientService;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    public String generateLoginPageUrl(SocialType provider) {
+        return oAuth2ClientService.generateLoginPageUrl(provider);
+    }
+
+    @Transactional
+    public OAuth2LoginResponseDto login(SocialType provider, String authorizationCode) {
+
+        // 소셜 제공자로부터 사용자 정보 조회
+        OAuth2UserInfo userInfo = oAuth2ClientService.getUserInfo(provider, authorizationCode);
+
+        // DB에서 사용자 조회 (없으면 등록)
+        User user = userRepository.findByEmailAndIsDeletedFalse(userInfo.getEmail())
+                .orElseGet(() -> registerIfAbsent(userInfo, provider));
+
+        // accessToken 발급
+        String accessToken = jwtUtil.createAccessToken(user);
+        // refreshToken 발급
+        String refreshToken = jwtUtil.createRefreshToken(user);
+
+        // redis 에 refreshToken 저장
+        refreshTokenRepository.save(user.getId(), refreshToken, refreshTokenExpiration);
+
+
+        return OAuth2LoginResponseDto.of(user, accessToken, refreshToken);
+    }
+
+    // OAuth2UserInfo 정보로 user 객체 만들기
+    private User registerIfAbsent(OAuth2UserInfo userInfo, SocialType provider) {
+        return userRepository.save(User.builder()
+                .name(userInfo.getName())
+                .email(userInfo.getEmail())
+                .phoneNumber(userInfo.getPhoneNumber())
+                .password(passwordEncoder.encode(UUID.randomUUID().toString())) // 임의의 비밀번호 사용
+                .socialType(provider)
+                .socialId(userInfo.getId())
+                .userRole(UserRole.MENTEE)
+                .userGrade(UserGrade.SEED)
+                .build());
+    }
+}

--- a/src/main/java/caffeine/nest_dev/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,17 @@
+package caffeine.nest_dev.oauth2.userinfo;
+
+import caffeine.nest_dev.domain.user.enums.SocialType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OAuth2UserInfo {
+
+    private SocialType provider;
+    private String id;
+    private String name;
+    private String email;
+    private String nickName;
+    private String phoneNumber;
+}

--- a/src/main/java/caffeine/nest_dev/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/userinfo/OAuth2UserInfo.java
@@ -10,8 +10,6 @@ public class OAuth2UserInfo {
 
     private SocialType provider;
     private String id;
-    private String name;
     private String email;
     private String nickName;
-    private String phoneNumber;
 }

--- a/src/main/java/caffeine/nest_dev/oauth2/userinfo/kakao/KakaoOAuth2Client.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/userinfo/kakao/KakaoOAuth2Client.java
@@ -1,0 +1,89 @@
+package caffeine.nest_dev.oauth2.userinfo.kakao;
+
+import caffeine.nest_dev.domain.user.enums.SocialType;
+import caffeine.nest_dev.oauth2.client.OAuth2Client;
+import caffeine.nest_dev.oauth2.userinfo.OAuth2UserInfo;
+import caffeine.nest_dev.oauth2.userinfo.kakao.dto.KakaoLoginUserInfoResponse;
+import caffeine.nest_dev.oauth2.userinfo.kakao.dto.KakaoTokenResponse;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuth2Client implements OAuth2Client {
+
+    private final RestClient restClient;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private final static String AUTH_SERVER_BASE_URL = "https://kauth.kakao.com";
+    private final static String RESOURCE_SERVER_BASE_URL = "https://kapi.kakao.com";
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUrl;
+
+    @Override
+    public SocialType getProvider() {
+        return SocialType.KAKAO;
+    }
+
+    @Override
+    public String getAccessToken(String authorizationCode) {
+        var body = new LinkedMultiValueMap<String, String>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUrl);
+        body.add("code", authorizationCode);
+
+        return restClient.post()
+                .uri(AUTH_SERVER_BASE_URL + "/oauth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, resp) -> {
+                    throw new RuntimeException("카카오 AccessToken 조회 실패");
+                })
+                .body(KakaoTokenResponse.class)
+                .getAccessToken();
+    }
+
+    @Override
+    public String generateLoginPageUrl() {
+        // state 랜덤 값으로 생성
+        String state = UUID.randomUUID().toString();
+
+        // redis에 저장
+        stringRedisTemplate.opsForValue().set("oauth2:state" + state, "Y", 5, TimeUnit.MINUTES);
+
+        return AUTH_SERVER_BASE_URL
+                + "/oauth/authorize"
+                + "?client_id=" + clientId
+                + "&redirect_uri=" + redirectUrl
+                + "&response_type=" + "code"
+                + "&state=" + state;
+    }
+
+    @Override
+    public OAuth2UserInfo retrieveUserInfo(String accessToken) {
+        Map<String, Object> attributes = restClient.get()
+                .uri(RESOURCE_SERVER_BASE_URL + "/v2/user/me")
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, resp) -> {
+                    throw new RuntimeException("카카오 UserInfo 조회 실패");
+                })
+                .body(Map.class); // Map 클래스는 제네릭 타입인데 타입을 지정해줘서 생기는 경고 (무시해도 런타임에 문제 X)
+
+        return new KakaoLoginUserInfoResponse(attributes);
+    }
+}

--- a/src/main/java/caffeine/nest_dev/oauth2/userinfo/kakao/dto/KakaoLoginUserInfoResponse.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/userinfo/kakao/dto/KakaoLoginUserInfoResponse.java
@@ -1,0 +1,56 @@
+package caffeine.nest_dev.oauth2.userinfo.kakao.dto;
+
+import caffeine.nest_dev.domain.user.enums.SocialType;
+import caffeine.nest_dev.oauth2.userinfo.OAuth2UserInfo;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class KakaoLoginUserInfoResponse extends OAuth2UserInfo {
+
+    public KakaoLoginUserInfoResponse(Map<String, Object> attributes) {
+        super(
+                SocialType.KAKAO,
+                String.valueOf(attributes.get("id")),
+                extractEmail(attributes),
+                extractNickName(attributes)
+        );
+    }
+
+    // name 파싱
+//    private static String extractName(Map<String, Object> attributes) {
+//        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+//        if (kakaoAccount != null) {
+//            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+//            if (profile != null) {
+//                return (String) profile.get("name");
+//            }
+//        }
+//        return null;
+//    }
+
+    // email 파싱
+    private static String extractEmail(Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+
+        if (kakaoAccount != null) {
+            return (String) kakaoAccount.get("email");
+        }
+        return null;
+    }
+
+    // kakao는 nickname을 profile.nickname 으로 넘겨줌
+    private static String extractNickName(Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+
+        if (kakaoAccount != null) {
+            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+            if (profile != null) {
+                return (String) profile.get("nickname");
+            }
+        }
+        return null;
+    }
+
+
+}

--- a/src/main/java/caffeine/nest_dev/oauth2/userinfo/kakao/dto/KakaoTokenResponse.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/userinfo/kakao/dto/KakaoTokenResponse.java
@@ -1,0 +1,14 @@
+package caffeine.nest_dev.oauth2.userinfo.kakao.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class) // 카카오 응답이 snake_case 여서 camelCase 와 매칭할 수 있도록
+public class KakaoTokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/src/main/java/caffeine/nest_dev/oauth2/userinfo/naver/NaverOAuth2Client.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/userinfo/naver/NaverOAuth2Client.java
@@ -1,0 +1,95 @@
+package caffeine.nest_dev.oauth2.userinfo.naver;
+
+import caffeine.nest_dev.domain.user.enums.SocialType;
+import caffeine.nest_dev.oauth2.client.OAuth2Client;
+import caffeine.nest_dev.oauth2.userinfo.OAuth2UserInfo;
+import caffeine.nest_dev.oauth2.userinfo.naver.dto.NaverLoginUserInfoResponse;
+import caffeine.nest_dev.oauth2.userinfo.naver.dto.NaverTokenResponse;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NaverOAuth2Client implements OAuth2Client {
+
+    private final RestClient restClient;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private static final String AUTH_SERVER_BASE_URL = "https://nid.naver.com";
+    private static final String RESOURCE_SERVER_BASE_URL = "https://openapi.naver.com";
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String clientId;
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String clientSecret;
+    @Value("${spring.security.oauth2.client.registration.naver.redirect-uri}")
+    private String redirectUrl;
+
+    @Override
+    public SocialType getProvider() {
+        return SocialType.NAVER;
+    }
+
+    @Override
+    public String getAccessToken(String authorizationCode) {
+        var body = new LinkedMultiValueMap<String, String>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("code", authorizationCode);
+        body.add("redirect_uri", redirectUrl);
+            return restClient.post()
+                    .uri(AUTH_SERVER_BASE_URL + "/oauth2.0/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, resp) -> {
+                        throw new RuntimeException("네이버 AccessToken 조회 실패");
+                    })
+                    .body(NaverTokenResponse.class)
+                    .getAccessToken();
+
+
+    }
+
+    @Override
+    public String generateLoginPageUrl() {
+        // state 생성
+        String state = UUID.randomUUID().toString();
+
+        // redis에 저장
+        stringRedisTemplate.opsForValue().set("oauth2:state" + state, "Y", 5, TimeUnit.MINUTES);
+
+        return AUTH_SERVER_BASE_URL
+                + "/oauth2.0/authorize"
+                + "?client_id=" + clientId
+                + "&response_type=code"
+                + "&redirect_uri=" + redirectUrl
+                + "&state=" + state; // CSRF 방지용 state 값 권장;
+    }
+
+    @Override
+    public OAuth2UserInfo retrieveUserInfo(String accessToken) {
+        Map<String, Object> attributes = restClient.get()
+                .uri(RESOURCE_SERVER_BASE_URL + "/v1/nid/me")
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, resp) -> {
+                    throw new RuntimeException("네이버 UserInfo 조회 실패");
+                })
+                .body(Map.class);
+
+        return new NaverLoginUserInfoResponse(attributes);
+    }
+}

--- a/src/main/java/caffeine/nest_dev/oauth2/userinfo/naver/dto/NaverLoginUserInfoResponse.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/userinfo/naver/dto/NaverLoginUserInfoResponse.java
@@ -1,0 +1,42 @@
+package caffeine.nest_dev.oauth2.userinfo.naver.dto;
+
+import caffeine.nest_dev.domain.user.enums.SocialType;
+import caffeine.nest_dev.oauth2.userinfo.OAuth2UserInfo;
+import java.util.Map;
+
+public class NaverLoginUserInfoResponse extends OAuth2UserInfo {
+
+
+    public NaverLoginUserInfoResponse(Map<String, Object> attributes) {
+        super(
+                SocialType.NAVER,
+                extractId(attributes),
+                extractEmail(attributes),
+                extractNickname(attributes)
+        );
+    }
+
+    // 고유 id 파싱
+    private static String extractId(Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return response != null ? (String) response.get("id") : null;
+    }
+
+    // 이름 파싱
+//    private static String extractName(Map<String, Object> attributes) {
+//        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+//        return response != null ? (String) response.get("name") : null;
+//    }
+
+    // 이메일 파싱
+    private static String extractEmail(Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return response != null ? (String) response.get("email") : null;
+    }
+
+    // 닉네임 파싱
+    private static String extractNickname(Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return response != null ? (String) response.get("nickname") : null;
+    }
+}

--- a/src/main/java/caffeine/nest_dev/oauth2/userinfo/naver/dto/NaverTokenResponse.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/userinfo/naver/dto/NaverTokenResponse.java
@@ -1,0 +1,16 @@
+package caffeine.nest_dev.oauth2.userinfo.naver.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverTokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+
+}


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
> closes #73 
>
> **제목 예시:** `feat : Pull request template 작성`
>
> (✅ 작성 후 이 안내 문구는 삭제해주세요)
>

--- OAuth2.0 을 활용한 소셜 로그인 구현

## 🔎 작업 내용

- 소셜 로그인 창으로 이동(/oauth2/login/{provider})
- 로그인 이후 RedirectUrl로 이동(/oauth2/callback/{provider})
- state 값 유효성 검증
- DB에서 사용자 조회 (없으면 신규 회원 등록)

---

## 🛠️ 변경 사항


---

## 🧩 트러블 슈팅

- 카카오는 로그인 요청시 카카오에서 내려주는 accessToken을 잘 받아옴
- 그러나 네이버는 accessToken을 못받와서 계속해서 null 이었음
- 아무리 시도해도 안 되길래 밥먹고 와서 돌려보니 정상적으로 작동 -> 로그인까지 완료!
- 코드 건든게 없는데 갑자기 됨! (무슨 문제인지 모름)

---

## 🧯 해결해야 할 문제


---

## 📌 참고 사항

- 프로퍼티스 설정 및 naver는 토큰 발급시 state 가 파라미터로 필수 값이나, 없어도 오류가 발생하지 않고 정상적으로 발급되고 있음.
- 혹시 나중에 에러 뜨면 state 부분부터 확인해야 할 듯?

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인