### PR TITLE
[#79, #78] Feat : 채팅방 자동종료, 대화내역 조회 기능 구현

### DIFF
--- a/src/main/java/caffeine/nest_dev/common/config/WebSocketConfig.java
+++ b/src/main/java/caffeine/nest_dev/common/config/WebSocketConfig.java
@@ -8,6 +8,8 @@ import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
+import org.springframework.web.socket.handler.WebSocketHandlerDecoratorFactory;
 
 /**
  * 웹소켓 메시지 브로커 설정 클래스 STOMP 프로토콜을 기반으로 하는 웹 소켓 통신 설정
@@ -22,6 +24,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
      */
     private final WebSocketAuthInterceptor webSocketAuthInterceptor;
     private final ChatHandshakeHandler chatHandshakeHandler;
+    private final WebSocketHandlerDecoratorFactory decoratorFactory;
 
     /**
      * STOMP 엔드포인트 등록 해당 엔드포인트로 웹소켓 연결
@@ -35,6 +38,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setAllowedOriginPatterns("*")  // cors 설정 (허용할 origin 지정)
                 .setHandshakeHandler(chatHandshakeHandler)
                 .withSockJS();  // 웹소켓을 지원하지 않는 브라우저도 사용할 수 있는 대체 옵션 지정
+    }
+
+    @Override
+    public void configureWebSocketTransport(WebSocketTransportRegistration registry) {
+        registry.addDecoratorFactory(decoratorFactory);
     }
 
     /**

--- a/src/main/java/caffeine/nest_dev/common/config/WebSocketDecoratorConfig.java
+++ b/src/main/java/caffeine/nest_dev/common/config/WebSocketDecoratorConfig.java
@@ -2,6 +2,7 @@ package caffeine.nest_dev.common.config;
 
 import caffeine.nest_dev.common.websocket.util.WebSocketSessionRegistry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.CloseStatus;
@@ -12,6 +13,7 @@ import org.springframework.web.socket.handler.WebSocketHandlerDecoratorFactory;
 /**
  * WebSocket 연결/종료 시점에 사용자 세션을 추적하기 위한 핸들러를 등록함
  */
+@Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class WebSocketDecoratorConfig {
@@ -32,6 +34,7 @@ public class WebSocketDecoratorConfig {
             @Override
             public void afterConnectionEstablished(WebSocketSession session) throws Exception {
                 String userId = session.getPrincipal().getName();
+                log.info("afterConnectionEstablished : userId = {}", userId);
                 sessionRegistry.register(userId, session);
                 super.afterConnectionEstablished(session);
             }
@@ -39,6 +42,7 @@ public class WebSocketDecoratorConfig {
             @Override
             public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus) throws Exception {
                 String userId = session.getPrincipal().getName();
+                log.info("afterConnectionClosed : userId = {}", userId);
                 sessionRegistry.sessionClose(userId);
                 super.afterConnectionClosed(session, closeStatus);
             }

--- a/src/main/java/caffeine/nest_dev/common/config/WebSocketDecoratorConfig.java
+++ b/src/main/java/caffeine/nest_dev/common/config/WebSocketDecoratorConfig.java
@@ -1,0 +1,47 @@
+package caffeine.nest_dev.common.config;
+
+import caffeine.nest_dev.common.websocket.util.WebSocketSessionRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.WebSocketHandlerDecorator;
+import org.springframework.web.socket.handler.WebSocketHandlerDecoratorFactory;
+
+/**
+ * WebSocket 연결/종료 시점에 사용자 세션을 추적하기 위한 핸들러를 등록함
+ */
+@Configuration
+@RequiredArgsConstructor
+public class WebSocketDecoratorConfig {
+
+    // 사용자 Id와 WebSocketSession을 매핑해 관리하는 세션 저장소
+    private final WebSocketSessionRegistry sessionRegistry;
+
+    /**
+     * WebSocketHandlerDecoratorFactory Bean 등록 WebSocket 메시지 처리 흐름에 커스텀 Decorator 삽입 이를 통해 연결된 사용자 세션을 추적하고 종료할 때 제거할 수
+     * 있음 userId마다 개별 Session을 가지고있음 -> 연결 종료시 두 명의 사용자의 세션 모두 종료시켜야 함
+     *
+     * @return 커스텀 WebSocketHandlerDecoratorFactory
+     */
+    @Bean
+    public WebSocketHandlerDecoratorFactory webSocketHandlerDecoratorFactory() {
+        return handler -> new WebSocketHandlerDecorator(handler) {
+
+            @Override
+            public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+                String userId = session.getPrincipal().getName();
+                sessionRegistry.register(userId, session);
+                super.afterConnectionEstablished(session);
+            }
+
+            @Override
+            public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus) throws Exception {
+                String userId = session.getPrincipal().getName();
+                sessionRegistry.sessionClose(userId);
+                super.afterConnectionClosed(session, closeStatus);
+            }
+        };
+    }
+}

--- a/src/main/java/caffeine/nest_dev/common/dto/SliceResponse.java
+++ b/src/main/java/caffeine/nest_dev/common/dto/SliceResponse.java
@@ -1,0 +1,35 @@
+package caffeine.nest_dev.common.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+
+@Getter
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+@Builder
+public class SliceResponse<T> {
+
+    private final List<T> content;
+    private final int currentPage;
+    private final int size;
+    private final boolean first;
+    private final boolean last;
+    private final boolean hasNext;
+    private final boolean hasPrevious;
+
+    public static <T> SliceResponse<T> of(Slice<T> slice) {
+        return SliceResponse.<T>builder()
+                .content(slice.getContent())
+                .currentPage(slice.getNumber())
+                .size(slice.getSize())
+                .first(slice.isFirst())
+                .last(slice.isLast())
+                .hasNext(slice.hasNext())
+                .hasPrevious(slice.hasPrevious())
+                .build();
+    }
+}

--- a/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
@@ -86,7 +86,9 @@ public enum ErrorCode implements BaseCode {
     // Consultation
     CONSULTATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상담 시간은 존재하지 않거나, 접근 권한이 없습니다."),
     DUPLICATE_CONSULTATION_TIME(HttpStatus.BAD_REQUEST, "이미 등록되어 있는 시간대 입니다."),
-    ;
+
+    // schedule
+    CHATROOM_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방 종료 스케줄이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/caffeine/nest_dev/common/websocket/util/WebSocketAuthInterceptor.java
+++ b/src/main/java/caffeine/nest_dev/common/websocket/util/WebSocketAuthInterceptor.java
@@ -41,7 +41,7 @@ public class WebSocketAuthInterceptor implements HandshakeInterceptor {
         // 토큰에서 userId를 추출해 저장 -> 소켓 세션에 저장
         Long userId = socketJwtUtil.getUserIdFromToken(token);
         attributes.put("userId", userId);
-        log.info("소켓 인증 성공 userId: {}", userId);
+        log.info("소켓 인증 성공 userId: {}", userId);    // 잘 들어감 key:"userId" value : userId
 
         return true;
     }

--- a/src/main/java/caffeine/nest_dev/common/websocket/util/WebSocketSessionRegistry.java
+++ b/src/main/java/caffeine/nest_dev/common/websocket/util/WebSocketSessionRegistry.java
@@ -1,0 +1,25 @@
+package caffeine.nest_dev.common.websocket.util;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
+
+@Component
+public class WebSocketSessionRegistry {
+
+    private final Map<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
+
+    // 사용자별로 세션 저장
+    public void register(String userId, WebSocketSession socketSession) {
+        sessions.put(userId, socketSession);
+    }
+
+    public void sessionClose(String userId) {
+        sessions.remove(userId);
+    }
+
+    public WebSocketSession getSession(String userId) {
+        return sessions.get(userId);
+    }
+}

--- a/src/main/java/caffeine/nest_dev/common/websocket/util/WebSocketSessionRegistry.java
+++ b/src/main/java/caffeine/nest_dev/common/websocket/util/WebSocketSessionRegistry.java
@@ -2,9 +2,11 @@ package caffeine.nest_dev.common.websocket.util;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
 
+@Slf4j
 @Component
 public class WebSocketSessionRegistry {
 
@@ -17,9 +19,13 @@ public class WebSocketSessionRegistry {
 
     public void sessionClose(String userId) {
         sessions.remove(userId);
+        log.info("남은 session 여부 (userId: {}): {}", userId, sessions.containsKey(userId));
+
     }
 
     public WebSocketSession getSession(String userId) {
+        log.info("session ID = {}", sessions.get(userId));
+        log.info("user ID = {}", sessions.keySet());
         return sessions.get(userId);
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/caffeine/nest_dev/domain/chatroom/controller/ChatRoomController.java
@@ -1,21 +1,29 @@
 package caffeine.nest_dev.domain.chatroom.controller;
 
 import caffeine.nest_dev.common.dto.CommonResponse;
+import caffeine.nest_dev.common.dto.SliceResponse;
 import caffeine.nest_dev.common.enums.SuccessCode;
 import caffeine.nest_dev.domain.chatroom.dto.request.CreateChatRoomRequestDto;
 import caffeine.nest_dev.domain.chatroom.dto.response.ChatRoomResponseDto;
+import caffeine.nest_dev.domain.chatroom.dto.response.MessageDto;
 import caffeine.nest_dev.domain.chatroom.service.ChatRoomService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -35,10 +43,8 @@ public class ChatRoomController {
     @PostMapping
     public ResponseEntity<CommonResponse<ChatRoomResponseDto>> createChatRooms(
             @RequestBody CreateChatRoomRequestDto requestDto
-//            @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         log.info("chatRoom 생성 api 진입");
-//        Long userId = userDetails.getId();
         ChatRoomResponseDto responseDto = chatRoomService.createChatRooms(requestDto);
         return ResponseEntity.created(URI.create("/api/chatrooms"))
                 .body(CommonResponse.of(SuccessCode.SUCCESS_CHATROOM_CREATED, responseDto));
@@ -57,6 +63,27 @@ public class ChatRoomController {
             @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         List<ChatRoomResponseDto> dtoList = chatRoomService.findAllChatRooms(userDetails.getId());
-        return ResponseEntity.ok().body(CommonResponse.of(SuccessCode.SUCCESS_CHATROOM_READ, dtoList));
+        return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.of(SuccessCode.SUCCESS_CHATROOM_READ, dtoList));
+    }
+
+    /**
+     * 채팅 내역 불러오기
+     *
+     * @param userDetails
+     * @param chatRoomId
+     * @param lastMessageId
+     * @param pageable
+     * @return
+     */
+    @GetMapping("/messages/{chatRoomId}")
+    public ResponseEntity<SliceResponse<MessageDto>> findAllMessages(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long chatRoomId,
+            @RequestParam(required = false) Long lastMessageId,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Long userId = userDetails.getId();
+        Slice<MessageDto> messageList = chatRoomService.findAllMessage(chatRoomId, userId, lastMessageId, pageable);
+        return ResponseEntity.status(HttpStatus.OK).body(SliceResponse.of(messageList));
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/chatroom/dto/response/MessageDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/chatroom/dto/response/MessageDto.java
@@ -1,0 +1,25 @@
+package caffeine.nest_dev.domain.chatroom.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MessageDto {
+
+    private Long messageId;
+    private Long chatRoomId;
+    private Long mentorId;
+    private Long menteeId;
+    private Long senderId;
+    private String content;
+    private LocalDateTime sentAt;
+    private boolean isMine; // 현재 로그인한 사용자인지 여부 -> 프론트에서 ui 정렬 시 편함
+}

--- a/src/main/java/caffeine/nest_dev/domain/chatroom/entity/ChatRoom.java
+++ b/src/main/java/caffeine/nest_dev/domain/chatroom/entity/ChatRoom.java
@@ -59,6 +59,3 @@ public class ChatRoom extends BaseEntity {
     }
 }
 
-/**
- * 예약식별자 유저식별자(멘토) 유저식별자(멘티) 대화 종료 여부 채팅방 생성일
- */

--- a/src/main/java/caffeine/nest_dev/domain/chatroom/entity/ChatRoom.java
+++ b/src/main/java/caffeine/nest_dev/domain/chatroom/entity/ChatRoom.java
@@ -54,7 +54,7 @@ public class ChatRoom extends BaseEntity {
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Message> messages = new ArrayList<>();
 
-    public void open() {
+    public void close() {
         this.isClosed = true;
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/caffeine/nest_dev/domain/chatroom/repository/ChatRoomRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomRepositoryQuery {
 
     Optional<ChatRoom> findByReservationId(Long reservationId);
 

--- a/src/main/java/caffeine/nest_dev/domain/chatroom/repository/ChatRoomRepositoryQuery.java
+++ b/src/main/java/caffeine/nest_dev/domain/chatroom/repository/ChatRoomRepositoryQuery.java
@@ -1,0 +1,11 @@
+package caffeine.nest_dev.domain.chatroom.repository;
+
+import caffeine.nest_dev.domain.chatroom.dto.response.MessageDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface ChatRoomRepositoryQuery {
+
+    Slice<MessageDto> findAllMessagesByChatRoomId(Long chatRoomId, Long messageId, Pageable pageable);
+
+}

--- a/src/main/java/caffeine/nest_dev/domain/chatroom/repository/ChatRoomRepositoryQueryImpl.java
+++ b/src/main/java/caffeine/nest_dev/domain/chatroom/repository/ChatRoomRepositoryQueryImpl.java
@@ -1,0 +1,65 @@
+package caffeine.nest_dev.domain.chatroom.repository;
+
+import static caffeine.nest_dev.domain.chatroom.entity.QChatRoom.chatRoom;
+import static caffeine.nest_dev.domain.message.entity.QMessage.message;
+
+import caffeine.nest_dev.domain.chatroom.dto.response.MessageDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+@RequiredArgsConstructor
+public class ChatRoomRepositoryQueryImpl implements ChatRoomRepositoryQuery {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Slice<MessageDto> findAllMessagesByChatRoomId(Long chatRoomId, Long messageId, Pageable pageable) {
+        List<MessageDto> results = jpaQueryFactory.select(Projections.fields(
+                        MessageDto.class,
+                        message.id.as("messageId"),
+                        chatRoom.id.as("chatRoomId"),
+                        message.mentor.id.as("mentorId"),
+                        message.mentee.id.as("menteeId"),
+                        message.sender.id.as("senderId"),
+                        message.content.as("content"),
+                        message.createdAt.as("sentAt")
+
+                ))
+                .from(message)
+                .where(
+                        message.chatRoom.id.eq(chatRoomId),
+                        lastMessageId(messageId)
+                )
+                .leftJoin(message.chatRoom, chatRoom)
+                .orderBy(message.createdAt.desc(), message.id.desc())   // 시간은 중복될 수 있음
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        return checkLastPage(pageable, results);
+    }
+
+    private BooleanExpression lastMessageId(Long messageId) {
+        if (messageId == null || messageId == 0) {
+            return null; // 조건 없이 최신부터 조회
+        }
+        return message.id.lt(messageId);
+    }
+
+    private Slice<MessageDto> checkLastPage(Pageable pageable, List<MessageDto> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageable.getPageSize()) {
+            hasNext = true;
+            results.remove(pageable.getPageSize());
+        }
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+}
+
+

--- a/src/main/java/caffeine/nest_dev/domain/chatroom/scheduler/entity/ChatRoomSchedule.java
+++ b/src/main/java/caffeine/nest_dev/domain/chatroom/scheduler/entity/ChatRoomSchedule.java
@@ -1,5 +1,6 @@
 package caffeine.nest_dev.domain.chatroom.scheduler.entity;
 
+import caffeine.nest_dev.domain.chatroom.scheduler.enums.ChatRoomType;
 import caffeine.nest_dev.domain.chatroom.scheduler.enums.ScheduleStatus;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -36,6 +37,9 @@ public class ChatRoomSchedule {
     // 채팅방 예약 상태
     @Enumerated(EnumType.STRING)
     private ScheduleStatus scheduleStatus;
+
+    @Enumerated(EnumType.STRING)
+    private ChatRoomType chatRoomType; // OPEN, CLOSE
 
     public void updateStatus() {
         this.scheduleStatus = ScheduleStatus.COMPLETE;

--- a/src/main/java/caffeine/nest_dev/domain/chatroom/scheduler/enums/ChatRoomType.java
+++ b/src/main/java/caffeine/nest_dev/domain/chatroom/scheduler/enums/ChatRoomType.java
@@ -1,0 +1,5 @@
+package caffeine.nest_dev.domain.chatroom.scheduler.enums;
+
+public enum ChatRoomType {
+    OPEN, CLOSE
+}

--- a/src/main/java/caffeine/nest_dev/domain/chatroom/scheduler/repository/ChatRoomScheduleRepository.java
+++ b/src/main/java/caffeine/nest_dev/domain/chatroom/scheduler/repository/ChatRoomScheduleRepository.java
@@ -1,12 +1,15 @@
 package caffeine.nest_dev.domain.chatroom.scheduler.repository;
 
 import caffeine.nest_dev.domain.chatroom.scheduler.entity.ChatRoomSchedule;
+import caffeine.nest_dev.domain.chatroom.scheduler.enums.ChatRoomType;
 import caffeine.nest_dev.domain.chatroom.scheduler.enums.ScheduleStatus;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomScheduleRepository extends JpaRepository<ChatRoomSchedule, Long> {
 
-    Optional<List<ChatRoomSchedule>> findAllByScheduleStatus(ScheduleStatus scheduleStatus);
+    List<ChatRoomSchedule> findAllByScheduleStatus(ScheduleStatus scheduleStatus);
+
+    List<ChatRoomSchedule> findAllByChatRoomTypeAndScheduleStatus(ChatRoomType chatRoomType,
+            ScheduleStatus scheduleStatus);
 }

--- a/src/main/java/caffeine/nest_dev/domain/chatroom/scheduler/service/ChatRoomCloseSchedulerService.java
+++ b/src/main/java/caffeine/nest_dev/domain/chatroom/scheduler/service/ChatRoomCloseSchedulerService.java
@@ -1,0 +1,140 @@
+package caffeine.nest_dev.domain.chatroom.scheduler.service;
+
+import caffeine.nest_dev.common.enums.ErrorCode;
+import caffeine.nest_dev.common.exception.BaseException;
+import caffeine.nest_dev.common.websocket.util.WebSocketSessionRegistry;
+import caffeine.nest_dev.domain.chatroom.entity.ChatRoom;
+import caffeine.nest_dev.domain.chatroom.repository.ChatRoomRepository;
+import caffeine.nest_dev.domain.chatroom.scheduler.entity.ChatRoomSchedule;
+import caffeine.nest_dev.domain.chatroom.scheduler.enums.ChatRoomType;
+import caffeine.nest_dev.domain.chatroom.scheduler.enums.ScheduleStatus;
+import caffeine.nest_dev.domain.chatroom.scheduler.repository.ChatRoomScheduleRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatRoomCloseSchedulerService {
+
+    // 스케줄링을 위한 빈
+    private final TaskScheduler taskScheduler;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomScheduleRepository chatRoomScheduleRepository;
+
+    // 사용자 Id , Session 매핑한 저장소
+    private final WebSocketSessionRegistry sessionRegistry;
+
+    // 서버 재시작 시 초기화 작업
+    @EventListener(ApplicationReadyEvent.class)
+    public void init() {
+        List<ChatRoomSchedule> scheduleList = chatRoomScheduleRepository.findAllByChatRoomTypeAndScheduleStatus(
+                ChatRoomType.CLOSE, ScheduleStatus.PENDING);
+
+        if (scheduleList.isEmpty()) {
+            log.info("저장된 종료 예약 작업이 없습니다.");
+            return;
+        }
+        log.info("예약 종료 스케줄 {}건", scheduleList.size());
+
+        // 예약시간이 지나지 않았다면 작업을 다시 등록함
+        for (ChatRoomSchedule roomSchedule : scheduleList) {
+            if (roomSchedule.getScheduledTime().isAfter(LocalDateTime.now())) {
+                taskScheduler.schedule(disconnectUsersAndCloseRoom(roomSchedule.getId()),
+                        java.sql.Date.from(roomSchedule.getScheduledTime().atZone(ZoneId.systemDefault()).toInstant()));
+                log.info("서버시작 후 실행되지 않은 작업이 등록되었습니다.");
+            }
+        }
+
+    }
+
+    /**
+     * 채팅방 종료 스케줄 등록 메서드
+     *
+     * @param reservationId 예약 ID
+     * @param endTime       예약 종료 시간 (채팅 종료 시간)
+     */
+    public void registerChatRoomCloseSchedule(Long reservationId, LocalDateTime endTime) {
+        ChatRoomSchedule closeSchedule = ChatRoomSchedule.builder()
+                .reservationId(reservationId)
+                .scheduledTime(endTime)
+                .scheduleStatus(ScheduleStatus.PENDING)
+                .chatRoomType(ChatRoomType.CLOSE)
+                .build();
+
+        ChatRoomSchedule saved = chatRoomScheduleRepository.save(closeSchedule);
+
+        // 종료 시각에 해당 채팅방을 닫는 작업 예약
+        taskScheduler.schedule(
+                disconnectUsersAndCloseRoom(saved.getId()),
+                Date.from(endTime.atZone(ZoneId.systemDefault()).toInstant())
+        );
+    }
+
+    /**
+     * 실제 채팅방을 종료하고 참여자의 세션을 닫는 작업을 Runnable 변환
+     *
+     * @param scheduleId 예약된 채팅 종료 작업 ID
+     * @return Runnable
+     */
+    private Runnable disconnectUsersAndCloseRoom(Long scheduleId) {
+        return () -> {
+            ChatRoomSchedule schedule = chatRoomScheduleRepository.findById(scheduleId).orElseThrow(
+                    () -> new BaseException(ErrorCode.CHATROOM_SCHEDULE_NOT_FOUND)
+            );
+
+            if (ScheduleStatus.COMPLETE.equals(schedule.getScheduleStatus())) {
+                log.info("이미 완료된 스케줄입니다. ID: {}", scheduleId);
+                return;
+            }
+
+            // 종료 후 상태 업데이트
+            schedule.updateStatus();
+            chatRoomScheduleRepository.save(schedule);
+
+            Long reservationId = schedule.getReservationId();
+            ChatRoom chatRoom = chatRoomRepository.findByReservationId(reservationId).orElseThrow(
+                    () -> new BaseException(ErrorCode.CHATROOM_NOT_FOUND)
+            );
+
+            // isClosed == true 설정
+            chatRoom.close();
+            chatRoomRepository.save(chatRoom);
+
+            // 사용자별 세션 종료
+            String mentorId = chatRoom.getMentor().getId().toString();
+            String menteeId = chatRoom.getMentee().getId().toString();
+            disconnectUser(mentorId);
+            disconnectUser(menteeId);
+
+            log.info("종료 예약 완료 : ScheduleId = {}", scheduleId);
+            log.info("채팅방 종료 완료 : ChatRoomId = {}, mentor = {}, mentee = {}", chatRoom.getId(), mentorId, menteeId);
+        };
+    }
+
+    /**
+     * 특정 사용자 ID의 WebSocket 세션 종료
+     *
+     * @param userId 종료할 사용자 ID
+     */
+    private void disconnectUser(String userId) {
+        WebSocketSession session = sessionRegistry.getSession(userId);
+        if (session != null && session.isOpen()) {
+            try {
+                session.close(new CloseStatus(4000, "채팅 종료"));
+            } catch (Exception e) {
+                log.warn("세션 종료 실패 : {}", userId, e);
+            }
+        }
+    }
+}

--- a/src/main/java/caffeine/nest_dev/domain/message/dto/request/MessageRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/message/dto/request/MessageRequestDto.java
@@ -2,6 +2,7 @@ package caffeine.nest_dev.domain.message.dto.request;
 
 import caffeine.nest_dev.domain.chatroom.entity.ChatRoom;
 import caffeine.nest_dev.domain.message.entity.Message;
+import caffeine.nest_dev.domain.user.entity.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -13,12 +14,13 @@ public class MessageRequestDto {
 
     private String content;
 
-    public Message toEntity(ChatRoom chatRoom) {
+    public Message toEntity(ChatRoom chatRoom, User user) {
         return Message.builder()
                 .chatRoom(chatRoom)
                 .reservation(chatRoom.getReservation())
                 .mentor(chatRoom.getMentor())
                 .mentee(chatRoom.getMentee())
+                .sender(user)
                 .content(this.getContent())
                 .build();
     }

--- a/src/main/java/caffeine/nest_dev/domain/message/entity/Message.java
+++ b/src/main/java/caffeine/nest_dev/domain/message/entity/Message.java
@@ -44,6 +44,7 @@ public class Message extends BaseEntity {
     @JoinColumn(name = "mentee_id", nullable = false)
     private User mentee;
 
+    // 보내는사람 식별
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id", nullable = false)
     private User sender;

--- a/src/main/java/caffeine/nest_dev/domain/message/entity/Message.java
+++ b/src/main/java/caffeine/nest_dev/domain/message/entity/Message.java
@@ -4,8 +4,21 @@ import caffeine.nest_dev.common.entity.BaseEntity;
 import caffeine.nest_dev.domain.chatroom.entity.ChatRoom;
 import caffeine.nest_dev.domain.reservation.entity.Reservation;
 import caffeine.nest_dev.domain.user.entity.User;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
@@ -14,6 +27,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Message extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -29,6 +43,10 @@ public class Message extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mentee_id", nullable = false)
     private User mentee;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
 
     @Lob // 대용량 데이터를 다뤄주는 어노테이션
     @Column(nullable = false)

--- a/src/main/resources/http/ReservationRequest.http
+++ b/src/main/resources/http/ReservationRequest.http
@@ -7,6 +7,6 @@ Authorization: Bearer {{authorizationToken}}
   "mentor": 2,
   "mentee": 1,
   "reservationStatus": "PAID",
-  "reservationStartAt": "2025-06-11 20:40:00",
-  "reservationEndAt": "2025-06-11 20:50:00"
+  "reservationStartAt": "2025-06-13 16:05:00",
+  "reservationEndAt": "2025-06-13 16:07:00"
 }

--- a/src/main/resources/http/chatlog.http
+++ b/src/main/resources/http/chatlog.http
@@ -1,0 +1,7 @@
+### GET request to example server
+GET {{root-path}}/api/chatrooms/messages/1
+Content-Type: application/json
+Authorization: Bearer {{authorizationToken}}
+
+
+###


### PR DESCRIPTION
Issue #78, #79  
close #79

---
issue
## 🔎 작업 내용

- 예약시간이 종료되면 채팅방이 close로 변경됨
- 채팅방에서 해당 채팅방에서 나눴던 대화 내용 검색 기능 추가
- slice 공통 응답 구현
---

## 🛠️ 변경 사항
- message entity 수정 -> 보낸사람을 식별하기 위해서 sender 추가. 기존엔 mentor/mentee로만 되어있어서 불러올 때 식별이 불가했음
- 관련된 파일 수정
---

## 🧩 트러블 슈팅

- 채팅은 종료되나 소켓연결이 끊어지지않는 문제 발생
-> 알림 기능은 문제 해결 이후 추가 할 예정입니다

---

## 🧯 해결해야 할 문제

- tcp 연결 종료가 제대로 되도록 해야함

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인